### PR TITLE
removes quote after url tag in all of .html

### DIFF
--- a/cabot/templates/base.html
+++ b/cabot/templates/base.html
@@ -32,7 +32,7 @@
   <div class="navbar navbar-default navbar-fixed-top">
     <div class="container">
       <div class="navbar-header">
-        <a href="{% url "services" %}" class="navbar-brand"><img src="{{ STATIC_URL }}arachnys/img/icon_48x48.png" width='20' height='20' /> Cabot by Arachnys</a>
+        <a href="{% url services %}" class="navbar-brand"><img src="{{ STATIC_URL }}arachnys/img/icon_48x48.png" width='20' height='20' /> Cabot by Arachnys</a>
         <button class="navbar-toggle" type="button" data-toggle="collapse" data-target="#navbar-main">
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
@@ -42,36 +42,36 @@
       <div class="navbar-collapse collapse" id="navbar-main">
         <ul class="nav navbar-nav">
           <li>
-            <a href="{% url "instances" %}"><i class="fa fa-desktop"></i> Instances</a>
+            <a href="{% url instances %}"><i class="fa fa-desktop"></i> Instances</a>
           </li>
           <li>
-            <a href="{% url "services" %}"><i class="fa fa-gears"></i> Services</a>
+            <a href="{% url services %}"><i class="fa fa-gears"></i> Services</a>
           </li>
           <li>
-            <a href="{% url "checks" %}"><i class="fa fa-cog"></i> Checks</a>
+            <a href="{% url checks %}"><i class="fa fa-cog"></i> Checks</a>
           </li>
           <ul class="nav navbar-nav navbar-left">
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="download">New <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="New">
                 <li>
-                  <a href="{% url "create-service" %}"><i class="fa fa-gears"></i> Service</a>
+                  <a href="{% url create-service %}"><i class="fa fa-gears"></i> Service</a>
                 </li>
                 <li>
-                  <a href="{% url "create-instance" %}"><i class="fa fa-desktop"></i> Instance</a>
+                  <a href="{% url create-instance %}"><i class="fa fa-desktop"></i> Instance</a>
                 </li>
                 <li class="divider"></li>
                 <li>
-                  <a href="{% url "create-graphite-check" %}?service={{ service.id }}&instance={{ instance.id }}" class=""><i class="glyphicon glyphicon-signal" title="Add new metric check"></i> Graphite check</a>
+                  <a href="{% url create-graphite-check %}?service={{ service.id }}&instance={{ instance.id }}" class=""><i class="glyphicon glyphicon-signal" title="Add new metric check"></i> Graphite check</a>
                 </li>
                 <li>
-                  <a href="{% url "create-http-check" %}?service={{ service.id }}&instance={{ instance.id }}" class="" title="Add new Http check"><i class="glyphicon glyphicon-arrow-up"></i> Http check</a>
+                  <a href="{% url create-http-check %}?service={{ service.id }}&instance={{ instance.id }}" class="" title="Add new Http check"><i class="glyphicon glyphicon-arrow-up"></i> Http check</a>
                 </li>
                 <li>
-                  <a href="{% url "create-jenkins-check" %}?service={{ service.id }}&instance={{ instance.id }}" class="" title="Add new Jenkins check"><i class="glyphicon glyphicon-ok"></i> Jenkins check</a>
+                  <a href="{% url create-jenkins-check %}?service={{ service.id }}&instance={{ instance.id }}" class="" title="Add new Jenkins check"><i class="glyphicon glyphicon-ok"></i> Jenkins check</a>
                 </li>
                 <li>
-                  <a href="{% url "create-icmp-check" %}?service={{ service.id }}&instance={{ instance.id }}" class="" title="Add new ICMP check"><i class="glyphicon glyphicon-transfer"></i> ICMP check</a>
+                  <a href="{% url create-icmp-check %}?service={{ service.id }}&instance={{ instance.id }}" class="" title="Add new ICMP check"><i class="glyphicon glyphicon-transfer"></i> ICMP check</a>
                 </li>
               </ul>
             </li>
@@ -79,10 +79,10 @@
         </ul>
         <ul class="nav navbar-nav navbar-right">
           <li>
-            <a href="{% url "subscriptions" %}"><i class="fa fa-table"></i> Alert subscriptions</a>
+            <a href="{% url subscriptions %}"><i class="fa fa-table"></i> Alert subscriptions</a>
           </li>
           <li>
-            <a href="{% url "shifts" %}"><i class="glyphicon glyphicon-time"></i> Duty rota</a>
+            <a href="{% url shifts %}"><i class="glyphicon glyphicon-time"></i> Duty rota</a>
           </li>
           {% if user.is_authenticated %}
           <li class="dropdown">

--- a/cabot/templates/cabotapp/_instance_list.html
+++ b/cabot/templates/cabotapp/_instance_list.html
@@ -20,7 +20,7 @@
       {% for instance in instances %}
         <tr class="enabled">
           <td>
-            <a href="{% url "instance" pk=instance.id %}" title="Alerts {% if instance.alerts_enabled %}enabled{% else %}disabled{% endif %}">{{instance.name}} </a>
+            <a href="{% url instance pk=instance.id %}" title="Alerts {% if instance.alerts_enabled %}enabled{% else %}disabled{% endif %}">{{instance.name}} </a>
           </td>
           <td>
             <span class="label label-{% if instance.overall_status == instance.PASSING_STATUS %}success{% else %}danger{% endif %}">{{ instance.overall_status|lower|capfirst }}</span>
@@ -32,7 +32,7 @@
             <span class="label label-{% if instance.inactive_status_checks.all.count > 0 %}warning{% else %}default{% endif %}">{{ instance.inactive_status_checks.all.count }}</span>
           </td>
           <td class="text-right">
-            <a class="btn btn-xs" href="{% url "update-instance" pk=instance.id %}" role="button">
+            <a class="btn btn-xs" href="{% url update-instance pk=instance.id %}" role="button">
               <i class="glyphicon glyphicon-edit"></i>
             </a>
           </td>

--- a/cabot/templates/cabotapp/_service_list.html
+++ b/cabot/templates/cabotapp/_service_list.html
@@ -20,7 +20,7 @@
       {% for service in services %}
         <tr class="{% if service.alerts_enabled %}enabled{% else %}warning{% endif %}">
           <td>
-            <a href="{% url "service" pk=service.id %}" title="Alerts {% if service.alerts_enabled %}enabled{% else %}disabled{% endif %}">{{service.name}} </a>
+            <a href="{% url service pk=service.id %}" title="Alerts {% if service.alerts_enabled %}enabled{% else %}disabled{% endif %}">{{service.name}} </a>
           </td>
           <td>
             <span class="label label-{% if not service.alerts_enabled %}warning{% else %}{% if service.overall_status == service.PASSING_STATUS %}success{% else %}danger{% endif %}{% endif %}">{% if service.alerts_enabled %}{{ service.overall_status|lower|capfirst }}{% else %}Disabled{% endif %}</span>
@@ -32,7 +32,7 @@
             <span class="label label-{% if service.inactive_status_checks.all.count > 0 %}warning{% else %}default{% endif %}">{{ service.inactive_status_checks.all.count }}</span>
           </td>
           <td class="text-right">
-            <a class="btn btn-xs" href="{% url "update-service" pk=service.id %}" role="button">
+            <a class="btn btn-xs" href="{% url update-service pk=service.id %}" role="button">
               <i class="glyphicon glyphicon-edit"></i>
             </a>
           </td>

--- a/cabot/templates/cabotapp/_statuscheck_list.html
+++ b/cabot/templates/cabotapp/_statuscheck_list.html
@@ -7,16 +7,16 @@
     <div class="col-xs-3 text-right">
       <h3>
       &nbsp;{% if checks_type == "All" or checks_type == "Graphite" %}
-      <a href="{% url "create-graphite-check" %}?instance={{ instance.id }}&service={{ service.id }}" class=""><i class="glyphicon glyphicon-plus" title="Add new metric check"></i><i class="glyphicon glyphicon-signal" title="Add new metric check"></i></a>
+      <a href="{% url create-graphite-check %}?instance={{ instance.id }}&service={{ service.id }}" class=""><i class="glyphicon glyphicon-plus" title="Add new metric check"></i><i class="glyphicon glyphicon-signal" title="Add new metric check"></i></a>
       {% endif %}
       {% if checks_type == "All" or checks_type == "Http" %}
-      &nbsp;<a href="{% url "create-http-check" %}?instance={{ instance.id }}&service={{ service.id }}" class="" title="Add new Http check"><i class="glyphicon glyphicon-plus"></i><i class="glyphicon glyphicon-arrow-up"></i></a>
+      &nbsp;<a href="{% url create-http-check %}?instance={{ instance.id }}&service={{ service.id }}" class="" title="Add new Http check"><i class="glyphicon glyphicon-plus"></i><i class="glyphicon glyphicon-arrow-up"></i></a>
       {% endif %}
       {% if checks_type == "All" or checks_type == "Jenkins" %}
-      &nbsp;<a href="{% url "create-jenkins-check" %}?instance={{ instance.id }}&service={{ service.id }}" class="" title="Add new Jenkins check"><i class="glyphicon glyphicon-plus"></i><i class="glyphicon glyphicon-ok"></i></a>
+      &nbsp;<a href="{% url create-jenkins-check %}?instance={{ instance.id }}&service={{ service.id }}" class="" title="Add new Jenkins check"><i class="glyphicon glyphicon-plus"></i><i class="glyphicon glyphicon-ok"></i></a>
       {% endif %}
       {% if checks_type == "All" or checks_type == "ICMP" %}
-      &nbsp;<a href="{% url "create-icmp-check" %}?instance={{ instance.id }}&service={{ service.id }}" class="" title="Add new ICMP check"><i class="glyphicon glyphicon-plus"></i><i class="glyphicon glyphicon-transfer"></i></a>
+      &nbsp;<a href="{% url create-icmp-check %}?instance={{ instance.id }}&service={{ service.id }}" class="" title="Add new ICMP check"><i class="glyphicon glyphicon-plus"></i><i class="glyphicon glyphicon-transfer"></i></a>
       {% endif %}
       </h3>
     </div>
@@ -48,7 +48,7 @@
       {% for check in checks %}
         <tr class="{% if check.active %}enabled{% else %}warning{% endif %}">
           <td title="{{ check.name }} - alerts {% if check.active %}enabled{% else %}disabled{% endif %}">
-            <a href="{% url "check" pk=check.id %}">{{check.name}}</a>
+            <a href="{% url check pk=check.id %}">{{check.name}}</a>
           </td>
           <td title="{{ check.calculated_status }}">
             {% if check.active %}
@@ -75,7 +75,7 @@
           <td>{{ check.get_importance_display }}</td>
           <td>
             {% for service in check.service_set.all %}
-            <a href="{% url "service" pk=service.id %}">{{ service.name }}</a>
+            <a href="{% url service pk=service.id %}">{{ service.name }}</a>
             {% if forloop.last %}
             {% else %}
             /
@@ -87,7 +87,7 @@
           </td>
           <td>
             {% for instance in check.instance_set.all %}
-            <a href="{% url "instance" pk=instance.id %}">{{ instance.name }}</a>
+            <a href="{% url instance pk=instance.id %}">{{ instance.name }}</a>
             {% if forloop.last %}
             {% else %}
             /
@@ -98,13 +98,13 @@
             {% endif %}
           </td>
           <td class="text-right">
-            <a class="btn btn-xs" href="{% if check.polymorphic_ctype.model == 'graphitestatuscheck' %}{% url "update-graphite-check" pk=check.id %}{% elif check.polymorphic_ctype.model == 'httpstatuscheck' %}{% url "update-http-check" pk=check.id %}{% elif check.polymorphic_ctype.model == 'icmpstatuscheck' %}{% url "update-icmp-check" pk=check.id %}{% elif check.polymorphic_ctype.model == 'jenkinsstatuscheck' %}{% url "update-jenkins-check" pk=check.id %}{% endif %}">
+            <a class="btn btn-xs" href="{% if check.polymorphic_ctype.model == 'graphitestatuscheck' %}{% url update-graphite-check pk=check.id %}{% elif check.polymorphic_ctype.model == 'httpstatuscheck' %}{% url update-http-check pk=check.id %}{% elif check.polymorphic_ctype.model == 'icmpstatuscheck' %}{% url update-icmp-check pk=check.id %}{% elif check.polymorphic_ctype.model == 'jenkinsstatuscheck' %}{% url update-jenkins-check pk=check.id %}{% endif %}">
               <i class="glyphicon glyphicon-edit"></i><span class="break"></span>
             </a>
-            <a class="btn btn-xs" href="{% if check.polymorphic_ctype.model == 'graphitestatuscheck' %}{% url "duplicate-graphite-check" pk=check.id %}{% elif check.polymorphic_ctype.model == 'httpstatuscheck' %}{% url "duplicate-http-check" pk=check.id %}{% elif check.polymorphic_ctype.model == 'icmpstatuscheck' %}{% url "duplicate-icmp-check" pk=check.id %}{% elif check.polymorphic_ctype.model == 'jenkinsstatuscheck' %}{% url "duplicate-jenkins-check" pk=check.id %}{% endif %}">
+            <a class="btn btn-xs" href="{% if check.polymorphic_ctype.model == 'graphitestatuscheck' %}{% url duplicate-graphite-check pk=check.id %}{% elif check.polymorphic_ctype.model == 'httpstatuscheck' %}{% url duplicate-http-check pk=check.id %}{% elif check.polymorphic_ctype.model == 'icmpstatuscheck' %}{% url duplicate-icmp-check pk=check.id %}{% elif check.polymorphic_ctype.model == 'jenkinsstatuscheck' %}{% url duplicate-jenkins-check pk=check.id %}{% endif %}">
               <i class="fa fa-copy"></i><span class="break"></span>
             </a>
-            <a class="btn btn-xs" href="{% url "run-check" pk=check.id %}">
+            <a class="btn btn-xs" href="{% url run-check pk=check.id %}">
               <i class="glyphicon glyphicon-refresh"></i><span class="break"></span>
             </a>
             {% if checks_type == "Jenkins" %}

--- a/cabot/templates/cabotapp/instance_detail.html
+++ b/cabot/templates/cabotapp/instance_detail.html
@@ -9,7 +9,7 @@
     <div class="col-xs-1"><h2><i class="fa fa-desktop"></i></h2></div>
     <div class="col-xs-5"><h2><span class="break"></span>{{ instance.name }}</h2></div>
     <div class="col-xs-4 text-right"><h2><span class="label label-{% if instance.overall_status == instance.PASSING_STATUS %}success{% else %}danger{% endif %}">{{ instance.overall_status|lower|capfirst }}</span> </h2></div>
-    <div class="col-xs-2 text-right"><h2><a class = "" href="{% url "duplicate-instance" instance.id %}"><i class="fa fa-copy"></i> </a><a class = "" href="{% url "update-instance" instance.id %}"><i class="glyphicon glyphicon-edit"></i> </a></h2></div>
+    <div class="col-xs-2 text-right"><h2><a class = "" href="{% url duplicate-instance instance.id %}"><i class="fa fa-copy"></i> </a><a class = "" href="{% url update-instance instance.id %}"><i class="glyphicon glyphicon-edit"></i> </a></h2></div>
   </div>
 </div>
 <hr>
@@ -90,7 +90,7 @@
       <h3>Status check report</h3>
     </div>
     <div class="col-xs-12">
-      <form action="{% url "checks-report" %}" method="get">
+      <form action="{% url checks-report %}" method="get">
         <div class="form-group">
           <div class="col-xs-12">
             {{ report_form.instance }}

--- a/cabot/templates/cabotapp/instance_form.html
+++ b/cabot/templates/cabotapp/instance_form.html
@@ -14,11 +14,11 @@
     <div class="form-group">
       <div class="col-xs-6 col-xs-offset-2">
         <button type="submit" class="btn btn-primary">Submit</button>
-        <a href="{% url "dashboard" %}" class="btn">Back to dashboard</a>
+        <a href="{% url dashboard %}" class="btn">Back to dashboard</a>
       </div>
       {% if form.instance.id %}
       <div class="col-xs-4">
-        <a class="btn btn-danger" href="{% url "delete-instance" form.instance.id %}">Delete instance</a>
+        <a class="btn btn-danger" href="{% url delete-instance form.instance.id %}">Delete instance</a>
       </div>
       {% endif %}
     </div>

--- a/cabot/templates/cabotapp/instance_list.html
+++ b/cabot/templates/cabotapp/instance_list.html
@@ -6,7 +6,7 @@
     <div class="col-xs-1"><h2><i class="fa fa-desktop"></i></h2></div>
     <div class="col-xs-10"><h2><span class="break"></span>Instances</h2></div>
     <div class="col-xs-1 text-right">
-      <h2><a href="{% url "create-instance" %}" title="New instance"><i class="glyphicon glyphicon-plus"></i></a></h2>
+      <h2><a href="{% url create-instance %}" title="New instance"><i class="glyphicon glyphicon-plus"></i></a></h2>
     </div>
   </div>
   <div class="col-xs-12">

--- a/cabot/templates/cabotapp/service_detail.html
+++ b/cabot/templates/cabotapp/service_detail.html
@@ -9,7 +9,7 @@
     <div class="col-xs-1"><h2><i class="fa fa-gears"></i></h2></div>
     <div class="col-xs-5"><h2><span class="break"></span>{{ service.name }}</h2></div>
     <div class="col-xs-4 text-right"><h2><span class="label label-{% if service.overall_status == service.PASSING_STATUS %}success{% else %}danger{% endif %}">{{ service.overall_status|lower|capfirst }}</span> <span class="label label-{% if service.alerts_enabled %}success{% else %}warning{% endif %}">{% if service.alerts_enabled %}Alerts enabled{%else %}Alerts disabled{% endif %}</span></h2></div>
-    <div class="col-xs-2 text-right"><h2><a href="{% url "update-service" service.id %}"><i class="glyphicon glyphicon-edit"></i></a></h2></div>
+    <div class="col-xs-2 text-right"><h2><a href="{% url update-service service.id %}"><i class="glyphicon glyphicon-edit"></i></a></h2></div>
   </div>
 </div>
 <hr>
@@ -61,7 +61,7 @@
     <div class="col-xs-8"><h3>Instances</h3></div>
     <div class="col-xs-3 text-right">
      <h3>
-          <a href="{% url "create-instance" %}?service={{ service.id }}" class=""><i class="glyphicon glyphicon-plus" title="Add new instance for this service"></i><i class="fa fa-desktop" title=""></i></a>
+          <a href="{% url create-instance %}?service={{ service.id }}" class=""><i class="glyphicon glyphicon-plus" title="Add new instance for this service"></i><i class="fa fa-desktop" title=""></i></a>
      </h3>
     </div>
 {% include 'cabotapp/_instance_list.html' with instances=service.instances.all %}
@@ -88,7 +88,7 @@
       <h3>Status check report</h3>
     </div>
     <div class="col-xs-12">
-      <form action="{% url "checks-report" %}" method="get">
+      <form action="{% url checks-report %}" method="get">
         <div class="form-group">
           <div class="col-xs-12">
             {{ report_form.service }}

--- a/cabot/templates/cabotapp/service_form.html
+++ b/cabot/templates/cabotapp/service_form.html
@@ -14,11 +14,11 @@
     <div class="form-group">
       <div class="col-xs-6 col-xs-offset-2">
         <button type="submit" class="btn btn-primary">Submit</button>
-        <a href="{% url "dashboard" %}" class="btn">Back to dashboard</a>
+        <a href="{% url dashboard %}" class="btn">Back to dashboard</a>
       </div>
       {% if form.instance.id %}
       <div class="col-xs-4">
-        <a class="btn btn-danger" href="{% url "delete-service" form.instance.id %}">Delete service</a>
+        <a class="btn btn-danger" href="{% url delete-service form.instance.id %}">Delete service</a>
       </div>
       {% endif %}
     </div>

--- a/cabot/templates/cabotapp/service_list.html
+++ b/cabot/templates/cabotapp/service_list.html
@@ -6,7 +6,7 @@
     <div class="col-xs-1"><h2><i class="fa fa-gears"></i></h2></div>
     <div class="col-xs-10"><h2><span class="break"></span>Services</h2></div>
     <div class="col-xs-1 text-right">
-      <h2><a href="{% url "create-service" %}" title="New service"><i class="glyphicon glyphicon-plus"></i></a></h2>
+      <h2><a href="{% url create-service %}" title="New service"><i class="glyphicon glyphicon-plus"></i></a></h2>
     </div>
   </div>
   <div class="col-xs-12">

--- a/cabot/templates/cabotapp/shift_list.html
+++ b/cabot/templates/cabotapp/shift_list.html
@@ -22,7 +22,7 @@
       {% for shift in shifts %}
         <tr>
           <td>
-            <a href="{% url "user-profile" pk=shift.user.id %}">{{ shift.user.username }}</a>
+            <a href="{% url user-profile pk=shift.user.id %}">{{ shift.user.username }}</a>
           </td>
           <td>
             {{ shift.start }} - {{ shift.end }}

--- a/cabot/templates/cabotapp/statuscheck_detail.html
+++ b/cabot/templates/cabotapp/statuscheck_detail.html
@@ -13,9 +13,9 @@
       {% if check.polymorphic_ctype.model == 'jenkinsstatuscheck' %}
         <a href="{% jenkins_human_url check.name %}" class=""><i class="glyphicon glyphicon-link"></i></a>
       {% endif %}
-      <a href="{% if check.polymorphic_ctype.model == 'graphitestatuscheck' %}{% url "update-graphite-check" pk=check.id %}{% elif check.polymorphic_ctype.model == 'httpstatuscheck' %}{% url "update-http-check" pk=check.id %}{% elif check.polymorphic_ctype.model == 'jenkinsstatuscheck' %}{% url "update-jenkins-check" pk=check.id %}{% elif check.polymorphic_ctype.model == 'icmpstatuscheck' %}{% url "update-icmp-check" pk=check.id %}{% endif %}" class=""><i class="glyphicon glyphicon-edit"></i>
-      <a href="{% if check.polymorphic_ctype.model == 'graphitestatuscheck' %}{% url "duplicate-graphite-check" pk=check.id %}{% elif check.polymorphic_ctype.model == 'httpstatuscheck' %}{% url "duplicate-http-check" pk=check.id %}{% elif check.polymorphic_ctype.model == 'jenkinsstatuscheck' %}{% url "duplicate-jenkins-check" pk=check.id %}{% elif check.polymorphic_ctype.model == 'icmpstatuscheck' %}{% url "duplicate-icmp-check" pk=check.id %}{% endif %}" class=""><i class="fa fa-copy"></i>
-      </a> <a href="{% url "run-check" pk=check.id %}"><i class="glyphicon glyphicon-refresh"></i></a>
+      <a href="{% if check.polymorphic_ctype.model == 'graphitestatuscheck' %}{% url update-graphite-check pk=check.id %}{% elif check.polymorphic_ctype.model == 'httpstatuscheck' %}{% url update-http-check pk=check.id %}{% elif check.polymorphic_ctype.model == 'jenkinsstatuscheck' %}{% url update-jenkins-check pk=check.id %}{% elif check.polymorphic_ctype.model == 'icmpstatuscheck' %}{% url update-icmp-check pk=check.id %}{% endif %}" class=""><i class="glyphicon glyphicon-edit"></i>
+      <a href="{% if check.polymorphic_ctype.model == 'graphitestatuscheck' %}{% url duplicate-graphite-check pk=check.id %}{% elif check.polymorphic_ctype.model == 'httpstatuscheck' %}{% url duplicate-http-check pk=check.id %}{% elif check.polymorphic_ctype.model == 'jenkinsstatuscheck' %}{% url duplicate-jenkins-check pk=check.id %}{% elif check.polymorphic_ctype.model == 'icmpstatuscheck' %}{% url duplicate-icmp-check pk=check.id %}{% endif %}" class=""><i class="fa fa-copy"></i>
+      </a> <a href="{% url run-check pk=check.id %}"><i class="glyphicon glyphicon-refresh"></i></a>
     </h2></div>
   </div>
 </div>
@@ -47,7 +47,7 @@
             </span>
           </td>
           <td>
-            <a href="{% url "result" pk=result.id %}">{{ result.time }}</a>
+            <a href="{% url result pk=result.id %}">{{ result.time }}</a>
           </td>
           <td>{{ result.time_complete }}</td>
           <td>{{ result.took }}</td>
@@ -65,7 +65,7 @@
   {% if service.hackpad_id %}
   <div class="col-xs-12">
     <div class="col-xs-1"><h3><i class="fa fa-exclamation-triangle"></i></h3></div>
-    <div class="col-xs-11"><h3>Recovery instructions for linked service <a href="{% url "service" service.id %}">{{ service.name }}</a></h3></div>
+    <div class="col-xs-11"><h3>Recovery instructions for linked service <a href="{% url service service.id %}">{{ service.name }}</a></h3></div>
     <div class="col-xs-12">
       <script src="{{ service.hackpad_id }}"></script>
     </div>

--- a/cabot/templates/cabotapp/statuscheck_form.html
+++ b/cabot/templates/cabotapp/statuscheck_form.html
@@ -14,11 +14,11 @@
     <div class="form-group">
       <div class="col-xs-6 col-xs-offset-2">
         <button type="submit" class="btn btn-primary">Submit</button>
-        <a href="{% url "dashboard" %}" class="btn">Back to dashboard</a>
+        <a href="{% url dashboard %}" class="btn">Back to dashboard</a>
       </div>
       {% if form.instance.id %}
       <div class="col-xs-4">
-        <a class="btn btn-danger" href="{% url "delete-check" form.instance.id %}">Delete check</a>
+        <a class="btn btn-danger" href="{% url delete-check form.instance.id %}">Delete check</a>
       </div>
       {% endif %}
       </div>

--- a/cabot/templates/cabotapp/statuscheckresult_detail.html
+++ b/cabot/templates/cabotapp/statuscheckresult_detail.html
@@ -5,7 +5,7 @@
   <div class="col-xs-12">
     <div class="col-xs-1"><h2><i class="glyphicon glyphicon-{% if result.check.polymorphic_ctype.model == 'graphitestatuscheck' %}signal{% elif result.check.polymorphic_ctype.model == 'httpstatuscheck' %}arrow-up{% elif result.check.polymorphic_ctype.model == 'jenkinsstatuscheck' %}ok{% endif %}"></i></h2></div>
     <div class="col-xs-9">
-      <h2>Check result: <a href="{% url "check" result.check.id %}">{{ result.check.name }}</a></h2>
+      <h2>Check result: <a href="{% url check result.check.id %}">{{ result.check.name }}</a></h2>
     </div>
     <div class="col-xs-2 text-right"><h2><span class="label label-{% if result.succeeded %}success{% else %}danger{% endif %}">{{ result.status|capfirst }}</span></h2></div>
   </div>

--- a/cabot/templates/cabotapp/subscriptions.html
+++ b/cabot/templates/cabotapp/subscriptions.html
@@ -29,7 +29,7 @@
             </span>
             {% endif %}
             {% endif %}
-            <a href="{% url "user-profile" pk=user.id %}" class="btn btn-xs">
+            <a href="{% url user-profile pk=user.id %}" class="btn btn-xs">
               <i class="glyphicon glyphicon-edit"></i>
             </a>
           </th>
@@ -40,7 +40,7 @@
       {% for service in services %}
         <tr class="{% if service.alerts_enabled %}enabled{% else %}warning{% endif %}" >
           <td title="{{ check.description }}">
-            <a href="{% url "update-service" pk=service.id %}">{{service.name}}</a>
+            <a href="{% url update-service pk=service.id %}">{{service.name}}</a>
             {% if service.email_alert %}<span class="label label-{% if service.alerts_enabled %}success{% else %}warning{% endif %}">email</span>{% endif %}
             {% if service.hipchat_alert %}<span class="label label-{% if service.alerts_enabled %}success{% else %}warning{% endif %}">hipchat</span>{% endif %}
             {% if service.sms_alert %}<span class="label label-{% if service.alerts_enabled %}success{% else %}warning{% endif %}">sms</span>{% endif %}

--- a/cabot/templates/cabotapp/userprofile_form.html
+++ b/cabot/templates/cabotapp/userprofile_form.html
@@ -17,7 +17,7 @@
   <div class="form-group">
     <div class="col-xs-6 col-xs-offset-2">
       <button type="submit" class="btn btn-primary">Submit</button>
-      <a href="{% url "dashboard" %}" class="btn">Back to dashboard</a>
+      <a href="{% url dashboard %}" class="btn">Back to dashboard</a>
     </div>
   </div>
 

--- a/cabot/templates/registration/login.html
+++ b/cabot/templates/registration/login.html
@@ -14,7 +14,7 @@
     <div class="form-group">
       <div class="col-xs-6 col-xs-offset-2">
         <button type="submit" class="btn btn-primary">Log in</button>
-        <a href="{% url "password-reset" %}" class="btn">Reset password</a>
+        <a href="{% url password-reset %}" class="btn">Reset password</a>
       </div>
       </div>
     </div>


### PR DESCRIPTION
This fix the following in Django 1.4.x:
NoReverseMatch: Reverse for '"instances"' with arguments '()' and keyword
arguments '{}' not found.
