### PR TITLE
Determine Graphite Check Range by Frequency

### DIFF
--- a/cabot/cabotapp/graphite.py
+++ b/cabot/cabotapp/graphite.py
@@ -11,7 +11,7 @@ auth = (user, password)
 
 def get_data(target_pattern, mins_to_check=None):
     if mins_to_check:
-        _from = '-'+str(mins_to_check)+'minute'
+        _from = '-%dminute' % mins_to_check
     else:
         _from = graphite_from
 

--- a/cabot/cabotapp/graphite.py
+++ b/cabot/cabotapp/graphite.py
@@ -9,13 +9,18 @@ graphite_from = settings.GRAPHITE_FROM
 auth = (user, password)
 
 
-def get_data(target_pattern):
+def get_data(target_pattern, mins_to_check=None):
+    if mins_to_check:
+        _from = '-'+str(mins_to_check)+'minute'
+    else:
+        _from = graphite_from
+
     resp = requests.get(
         graphite_api + 'render', auth=auth,
         params={
             'target': target_pattern,
             'format': 'json',
-            'from': graphite_from
+            'from': _from
         }
     )
     resp.raise_for_status()
@@ -69,7 +74,7 @@ def parse_metric(metric, mins_to_check=5):
         'raw': ''
     }
     try:
-        data = get_data(metric)
+        data = get_data(metric, mins_to_check)
     except requests.exceptions.RequestException, e:
         ret['error'] = 'Error getting data from Graphite: %s' % e
         ret['raw'] = ret['error']

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -150,10 +150,10 @@ class GraphiteStatusCheckForm(StatusCheckForm):
         model = GraphiteStatusCheck
         fields = (
             'name',
+            'frequency',
             'metric',
             'check_type',
             'value',
-            'frequency',
             'active',
             'importance',
             'expected_num_hosts',
@@ -422,7 +422,7 @@ class CheckCreateView(LoginRequiredMixin, CreateView):
             return reverse('service', kwargs={'pk': self.request.GET.get('service')})
         if self.request.GET.get('instance'):
             return reverse('instance', kwargs={'pk': self.request.GET.get('instance')})
-        return reverse('checks')  
+        return reverse('checks')
 
 
 class CheckUpdateView(LoginRequiredMixin, UpdateView):
@@ -687,10 +687,11 @@ def jsonify(d):
 @login_required
 def graphite_api_data(request):
     metric = request.GET.get('metric')
+    mins_to_check = request.GET.get('frequency')
     data = None
     matching_metrics = None
     try:
-        data = get_data(metric)
+        data = get_data(metric, mins_to_check)
     except requests.exceptions.RequestException, e:
         pass
     if not data:

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -687,7 +687,7 @@ def jsonify(d):
 @login_required
 def graphite_api_data(request):
     metric = request.GET.get('metric')
-    mins_to_check = request.GET.get('frequency')
+    mins_to_check = int(request.GET.get('frequency'))
     data = None
     matching_metrics = None
     try:

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -687,7 +687,12 @@ def jsonify(d):
 @login_required
 def graphite_api_data(request):
     metric = request.GET.get('metric')
-    mins_to_check = int(request.GET.get('frequency'))
+
+    if request.GET.get('frequency'):
+        mins_to_check = int(request.GET.get('frequency'))
+    else:
+        mins_to_check = None
+
     data = None
     matching_metrics = None
     try:

--- a/cabot/templates/cabotapp/statuscheck_form.html
+++ b/cabot/templates/cabotapp/statuscheck_form.html
@@ -37,6 +37,7 @@ GRAPHITE_ENDPOINT = '/graphite/'
 $(document).ready ->
   updateGraphiteData()
   $('#id_metric').on('keyup', updateGraphiteData)
+  $('#id_frequency').on('keyup', updateGraphiteData)
 
   $('#id_metric').autocomplete
     source: (request, response) ->
@@ -57,10 +58,12 @@ $(document).ready ->
 updateGraphiteData = () ->
   $('#graphite_data_container').text 'Getting data'
   m = $('#id_metric').val()
+  f = $('#id_frequency').val()
   $.ajax
     url: GRAPHITE_ENDPOINT
     data:
       metric: m
+      frequency: f
   .done (data) ->
     if data.data? and data.data.length? != 0
       $('#graphite_data_container').text JSON.stringify(data.data, undefined, 2)


### PR DESCRIPTION
I was having a problem checking metrics that update less frequently than the default 10 minutes.

I could have increased the global GRAPHITE_FROM but I preferred the range to be determined by the check's frequency.

This PR also makes the metric preview graph show the correct range as the frequency is modified.
