### PR TITLE
Add URL to service API

### DIFF
--- a/cabot/rest_urls.py
+++ b/cabot/rest_urls.py
@@ -61,7 +61,9 @@ check_group_mixin_fields = (
 
 router.register(r'services', create_viewset(
     arg_model=models.Service, 
-    arg_fields=check_group_mixin_fields,
+    arg_fields=check_group_mixin_fields + (
+        'url',
+    ),
 ))
 
 router.register(r'instances', create_viewset(


### PR DESCRIPTION
The url field in services is currently not exposed through the API.  This patch exposes it.
