### PR TITLE
Updated the unit tests so that they will pass

### DIFF
--- a/cabot/cabotapp/tests/tests_basic.py
+++ b/cabot/cabotapp/tests/tests_basic.py
@@ -411,7 +411,8 @@ class TestAPI(LocalTestCase):
                     'sms_alert': False,
                     'telephone_alert': False,
                     'hackpad_id': None,
-                    'id': 1
+                    'id': 1,
+                    'url': u''
                 },
             ],
             'instance': [
@@ -528,7 +529,8 @@ class TestAPI(LocalTestCase):
                     'sms_alert': False,
                     'telephone_alert': False,
                     'hackpad_id': None,
-                    'id': 2
+                    'id': 2,
+                    'url': u'',
                 },
             ],
             'instance': [


### PR DESCRIPTION
The original unit tests were not expecting a URL attribute to be returned when an API call was made to list Service info.
