### PR TITLE
Make Cabot work on 14.04 as well as 12.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ celerybeat-schedule
 *.orig
 .vagrant
 conf/*.env
+local_config.yml

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,8 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Load local config overrides
+local_config = File.file?("local_config.yml") ? YAML.load(File.read("local_config.yml")) : {}
 
 Vagrant::configure("2") do |config|
   # All Vagrant configuration is done here. The most common configuration
@@ -5,15 +10,23 @@ Vagrant::configure("2") do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "precise64"
+  config.vm.box = local_config["box"] || "hashicorp/precise64"
 
-  config.vm.provider "virtualbox" do |v|
-    v.customize ["modifyvm", :id, "--memory", "1024", "--cpus", "1"]
+  # Virtualbox
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize [
+      "modifyvm", :id,
+      "--memory", local_config['ram'] || "1024",
+      "--cpus", local_config['cpu'] || 1,
+      "--ioapic", "on",
+    ]
   end
 
-  # The url from where the 'config.vm.box' box will be fetched if it
-  # doesn't already exist on the user's system.
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  #vmware_fusion
+  config.vm.provider "vmware_fusion" do |v|
+    v.vmx["memsize"] = local_config['ram'] || "1024"
+    v.vmx["numvcpus"] = local_config['cpu'] || 1
+  end
 
   # Boot with a GUI so you can see the screen. (Default is headless)
   # config.vm.boot_mode = :gui

--- a/bin/provision
+++ b/bin/provision
@@ -17,12 +17,24 @@ PACKAGES=(
   'redis-server'
 )
 
+# OS-specific install instructions
+case $(lsb_release -sc) in
+  "precise")
+    # add-apt-repository is not available in the base system
+    if ! which add-apt-repository; then
+      apt-get update
+      apt-get install -y python-software-properties
+    fi
+  ;;
+  "trusty")
+    # add-apt-repository is not available in the base system
+    if ! which add-apt-repository; then
+      apt-get update
+      apt-get install -y software-properties-common
+    fi
+  ;;
+esac
 
-# add-apt-repository is not available in the base system
-if ! which add-apt-repository; then
-  apt-get update
-  apt-get install -y python-software-properties
-fi
 
 add-apt-repository -y ppa:chris-lea/redis-server
 apt-get update
@@ -30,6 +42,9 @@ apt-get update
 apt-get install -y --force-yes ${PACKAGES[@]}
 
 gem install foreman
+
+# ubuntu 14.04 has `nodejs` not `node`
+[ ! -f /usr/bin/node ] && ln -s /usr/bin/nodejs /usr/bin/node
 
 pip install virtualenv
 if [ ! -d /home/vagrant/venv ]; then

--- a/bin/setup_dependencies.sh
+++ b/bin/setup_dependencies.sh
@@ -51,18 +51,32 @@ packages=(
   'build-essential'
   'redis-server'
   'libpq-dev'
-  'rubygems'
   'libxml2-dev'
   'libxslt-dev'
   'nodejs'
   'npm'
-  'postgresql-9.1'
+  'postgresql'
   'nginx'
   'htop'
 )
 
 sudo apt-get update
 sudo apt-get install --quiet --assume-yes ${packages[*]}
+
+# install ruby if it's not installed
+if ! which ruby; then
+  sudo apt-get install -y ruby1.9.3
+fi
+
+# install rubygems if it's not included in ruby
+if ! which gem; then
+  sudo apt-get install -y rubygems
+fi
+
+# symlink node to nodejs for 14.04 compatibility
+if ! which node && which nodejs; then
+  sudo ln -s `which nodejs` /usr/bin/node
+fi
 set +e
 sudo pip install -U pip # upgrade pip
 set -e

--- a/example_local_config.yml
+++ b/example_local_config.yml
@@ -1,0 +1,13 @@
+---
+# Example Local Vagrant config
+# With this file, you can override the amount of RAM and CPUs allocated
+# to the VM, as well as change the base box it uses. Just copy it to
+# local_config.yml and edit with whatever values you want.
+#
+# Note that it doesn't take effect until you vagrant destroy && vagrant up
+
+# double your pleasure double your CPU and RAM
+ram: 2048
+cpu: 2
+# hashicorp ubuntu doesn't support VMWare, so use box-cutter
+box: box-cutter/ubuntu1404


### PR DESCRIPTION
I updated the provisioning script to work on both 12.04 and 14.04, and made it possible to change the vagrant box (as well as amount of RAM and CPU) by adding a local_config.yml file that overrides settings (but is ignored by git).

12.04 is still the default, but 14.04 installs correctly on vagrant (tested on vmware), and on AWS. Fixes #122

Let me know if anything looks weird; I'd be happy to discuss or change it.