### PR TITLE
Fix tests failing because of http vs https

### DIFF
--- a/cabot/cabotapp/tests/tests_basic.py
+++ b/cabot/cabotapp/tests/tests_basic.py
@@ -777,12 +777,12 @@ class TestAlerts(LocalTestCase):
         self.user.is_active = True
         self.user.save()
         self.service.alert()
-        fake_hipchat_alert.assert_called_with(u'Service Service is back to normal: https://localhost/service/1/.  @test_user_hipchat_alias', color='green', sender='Cabot/Service')
+        fake_hipchat_alert.assert_called_with(u'Service Service is back to normal: http://localhost/service/1/.  @test_user_hipchat_alias', color='green', sender='Cabot/Service')
 
         self.user.is_active = False
         self.user.save()
         self.service.alert()
-        fake_hipchat_alert.assert_called_with(u'Service Service is back to normal: https://localhost/service/1/. ', color='green', sender='Cabot/Service')
+        fake_hipchat_alert.assert_called_with(u'Service Service is back to normal: http://localhost/service/1/. ', color='green', sender='Cabot/Service')
 
 
     @patch('cabot.cabotapp.alert._send_hipchat_alert')
@@ -793,7 +793,7 @@ class TestAlerts(LocalTestCase):
         self.service.save()
 
         self.service.alert()
-        fake_hipchat_alert.assert_called_with(u'Service Service is back to normal: https://localhost/service/1/.  @test_user_hipchat_alias', color='green', sender='Cabot/Service')
+        fake_hipchat_alert.assert_called_with(u'Service Service is back to normal: http://localhost/service/1/.  @test_user_hipchat_alias', color='green', sender='Cabot/Service')
 
     @patch('cabot.cabotapp.alert._send_hipchat_alert')
     def test_failure_alert(self, fake_hipchat_alert):
@@ -803,4 +803,4 @@ class TestAlerts(LocalTestCase):
         self.service.save()
 
         self.service.alert()
-        fake_hipchat_alert.assert_called_with(u'Service Service reporting failing status: https://localhost/service/1/. Checks failing: @test_user_hipchat_alias', color='red', sender='Cabot/Service')
+        fake_hipchat_alert.assert_called_with(u'Service Service reporting failing status: http://localhost/service/1/. Checks failing: @test_user_hipchat_alias', color='red', sender='Cabot/Service')


### PR DESCRIPTION
It looks like https://github.com/arachnys/cabot/commit/b84c524753d612b277c5287487a7e1da8c38c7d3 changed the HipChat tests to reference `https://localhost/service/1/` rather than `http://localhost/service/1/`, but on Travis and my local machine using `https` makes the tests fail. This PR switches the tests back to http, which makes them pass.