### PR TITLE
fixed cabot API: instances field is not exposed to /api/services/

### DIFF
--- a/cabot/cabotapp/tests/tests_basic.py
+++ b/cabot/cabotapp/tests/tests_basic.py
@@ -413,6 +413,7 @@ class TestAPI(LocalTestCase):
                     'sms_alert': False,
                     'telephone_alert': False,
                     'hackpad_id': None,
+                    'instances': [],
                     'id': 1,
                     'url': u''
                 },
@@ -531,6 +532,7 @@ class TestAPI(LocalTestCase):
                     'sms_alert': False,
                     'telephone_alert': False,
                     'hackpad_id': None,
+                    'instances': [],
                     'id': 2,
                     'url': u'',
                 },

--- a/cabot/rest_urls.py
+++ b/cabot/rest_urls.py
@@ -63,6 +63,7 @@ router.register(r'services', create_viewset(
     arg_model=models.Service, 
     arg_fields=check_group_mixin_fields + (
         'url',
+        'instances',
     ),
 ))
 


### PR DESCRIPTION
Same as https://github.com/arachnys/cabot/pull/172
Fixed commits to look cleaner