### PR TITLE
Remove 'No URL file' error message and set default versions for plugins.

### DIFF
--- a/cabot/urls.py
+++ b/cabot/urls.py
@@ -150,7 +150,7 @@ def append_plugin_urls():
         try:
             _module = import_module('%s.urls' % plugin)
         except Exception as e:
-            logger.error('No url file available for plugin %s' % plugin)
+            pass
         else:
             urlpatterns += patterns('',
                 url(r'^plugins/%s/' % plugin, include('%s.urls' % plugin))

--- a/conf/development.env.example
+++ b/conf/development.env.example
@@ -1,5 +1,5 @@
 # Plugins to be loaded at launch
-CABOT_PLUGINS_ENABLED=cabot_alert_hipchat,cabot_alert_twilio,cabot_alert_email
+CABOT_PLUGINS_ENABLED=cabot_alert_hipchat==1.6.1,cabot_alert_twilio==1.6.1,cabot_alert_email==1.3.1
 
 DEBUG=t
 DATABASE_URL=sqlite:///dev.db

--- a/conf/production.env.example
+++ b/conf/production.env.example
@@ -1,5 +1,5 @@
 # Plugins to be loaded at launch
-CABOT_PLUGINS_ENABLED=cabot_alert_hipchat,cabot_alert_twilio,cabot_alert_email
+CABOT_PLUGINS_ENABLED=cabot_alert_hipchat==1.6.1,cabot_alert_twilio==1.1.4,cabot_alert_email==1.3.1
 
 DATABASE_URL=postgres://cabot:cabot@localhost:5432/index
 DJANGO_SETTINGS_MODULE=cabot.settings


### PR DESCRIPTION
By specifying versions explicitly, a person can upgrade their plugins by redeploying.