### PR TITLE
Using defined values in backup task

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -151,7 +151,12 @@ def backup():
     """
     backup_file = 'outfile.sql.gz'
     with cd(BACKUP_DIR):
-        run('PGPASSWORD=cabot pg_dump -U cabot index | gzip > {}'.format(backup_file))
+        run('PGPASSWORD={passwd} pg_dump -U {user} {database} | gzip > {backup}'.format(
+            passwd=PG_PASSWORD,
+            user=PG_USERNAME,
+            database=PG_DATABASE,
+            backup=backup_file
+            ))
         get(backup_file, 'backups/%(basename)s')
 
 


### PR DESCRIPTION
The backup fabric task was using hardcoded values that represented the
defaults for the PG_* values. This change makes use of the variables so
that the task works in different environments