### PR TITLE
Correct a link pointing to Quickstart

### DIFF
--- a/_posts/2014-01-08-configuration.md
+++ b/_posts/2014-01-08-configuration.md
@@ -14,7 +14,7 @@ All configuration takes place through environment variables managed by Foreman.
 
 Production configuration lives in `conf/production.env`. You should copy and customise the template file included as `conf/production.env.example`.
 
-To change env variables on a running instance, modify `conf/production.env` locally and deploy your changes with `fab deploy -H ubuntu@your.server.hostname` (as in the [5th step of the quickstart guide](quickstart.html)).
+To change env variables on a running instance, modify `conf/production.env` locally and deploy your changes with `fab deploy -H ubuntu@your.server.hostname` (as in the [5th step of the quickstart guide](/qs/quickstart.html)).
 
 #### Development
 


### PR DESCRIPTION
This corrects a wrong link to Quickstart page in http://cabotapp.com/use/configuration.html (the one under "5th step of the quickstart guide").