### PR TITLE
Add support to override cabot templates and URLs

### DIFF
--- a/cabot/settings.py
+++ b/cabot/settings.py
@@ -86,8 +86,8 @@ SECRET_KEY = os.environ.get(
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
     'django.template.loaders.app_directories.Loader',
+    'django.template.loaders.filesystem.Loader',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/cabot/urls.py
+++ b/cabot/urls.py
@@ -147,13 +147,24 @@ def append_plugin_urls():
     """
     global urlpatterns
     for plugin in settings.CABOT_PLUGINS_ENABLED_PARSED:
+        override_url = False
+
         try:
             _module = import_module('%s.urls' % plugin)
         except Exception as e:
             pass
         else:
-            urlpatterns += patterns('',
-                url(r'^plugins/%s/' % plugin, include('%s.urls' % plugin))
+            try:
+                override_url = _module.override_url
+            except Exception, e:
+                pass
+
+            if override_url is False:
+                logger.info(override_url)
+                urlpatterns += patterns('',
+                    url(r'^plugins/%s/' % plugin, include('%s.urls' % plugin))
                 )
+            else:
+                urlpatterns =  _module.urlpatterns + urlpatterns
 
 append_plugin_urls()


### PR DESCRIPTION
This changes allows a plugin to override any of the default cabot templates and URL while keeping support for the old behavior.