### PR TITLE
Convert *_INTERVAL variables to int

### DIFF
--- a/cabot/cabot_config.py
+++ b/cabot/cabot_config.py
@@ -10,8 +10,8 @@ JENKINS_PASS = os.environ.get('JENKINS_PASS')
 CALENDAR_ICAL_URL = os.environ.get('CALENDAR_ICAL_URL')
 WWW_HTTP_HOST = os.environ.get('WWW_HTTP_HOST')
 WWW_SCHEME = os.environ.get('WWW_SCHEME', "https")
-ALERT_INTERVAL = os.environ.get('ALERT_INTERVAL', 10)
-NOTIFICATION_INTERVAL = os.environ.get('NOTIFICATION_INTERVAL', 120)
+ALERT_INTERVAL = int(os.environ.get('ALERT_INTERVAL', 10))
+NOTIFICATION_INTERVAL = int(os.environ.get('NOTIFICATION_INTERVAL', 120))
 
 # Default plugins are used if the user has not specified.
 CABOT_PLUGINS_ENABLED = os.environ.get('CABOT_PLUGINS_ENABLED', 'cabot_alert_hipchat,cabot_alert_twilio,cabot_alert_email')


### PR DESCRIPTION
`ALERT_INTERVAL` and `NOTIFICATION_INTERVAL` are now converted to numbers. This allows user-defined `ALERT_INTERVAL` and `NOTIFICATION_INTERVAL` env variables to work without throwing `TypeError`s:

```
    return self.run(*args, **kwargs)
  File "/cabot/cabot/cabotapp/tasks.py", line 68, in update_service
    service.update_status()
  File "/cabot/cabot/cabotapp/models.py", line 243, in update_status
    self.alert()
  File "/cabot/cabot/cabotapp/models.py", line 174, in alert
    if self.last_alert_sent and (timezone.now() - timedelta(minutes=settings.ALERT_INTERVAL)) < self.last_alert_sent:
TypeError: unsupported type for timedelta minutes component: str
```