### PR TITLE
example production env tweak

### DIFF
--- a/conf/production.env.example
+++ b/conf/production.env.example
@@ -25,7 +25,7 @@ CALENDAR_ICAL_URL=http://www.google.com/calendar/ical/example.ics
 CELERY_BROKER_URL=redis://:yourrediskey@localhost:6379/1
 DJANGO_SECRET_KEY=2FL6ORhHwr5eX34pP9mMugnIOd3jzVuT45f7w430Mt5PnEwbcJgma0q8zUXNZ68A
 
-# Hostname of your Graphite server instance
+# Hostname of your Graphite server instance (including trailing slash)
 GRAPHITE_API=http://graphite.example.com/
 GRAPHITE_USER=username
 GRAPHITE_PASS=password


### PR DESCRIPTION
Only including this as it got me for a little while - a reminder that Cabot won't see your graphite server if you leave off the trailing slash.

(It tries to access `graphite.example.comevents` instead of joining the URL together with a slash if not already present- suggest using `urljoin` to prevent this?)