### PR TITLE
Increasing the valid size of the email field.

### DIFF
--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -575,7 +575,7 @@ def get_object_form(model_type):
 class GeneralSettingsForm(forms.Form):
     first_name = forms.CharField(label='First name', max_length=30, required=False)
     last_name  = forms.CharField(label='Last name', max_length=30, required=False)
-    email_address = forms.CharField(label='Email Address', max_length=30, required=False)
+    email_address = forms.CharField(label='Email Address', max_length=75, required=False) #We use 75 and not the 254 because Django 1.6.8 only supports 75. See commit message for details.
     enabled = forms.BooleanField(label='Enabled', required=False)
 
 class InstanceListView(LoginRequiredMixin, ListView):

--- a/cabot/templates/cabotapp/instance_confirm_delete.html
+++ b/cabot/templates/cabotapp/instance_confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h1>Delete service</h1>
+<h1>Delete instance</h1>
 <form action="." method="post">{% csrf_token %}
   <button type="submit" class="btn btn-danger">Delete {{ object }}</button>
 </form>


### PR DESCRIPTION
The longest valid email is 254 bytes:
https://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address
http://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690

However, Django 1.6.8 has a default maximum of 75 (https://github.com/django/django/blob/811508b0512d3fa6b2328f8647fbf9eace68eceb/django/db/models/fields/__init__.py#L994). While we could override this limit, but I don't think we should "patch Django in Cabot".

If we ever move to Django 1.8.x, we can increase this to 254.
