### PR TITLE
If statement wasn't checking for None correctly, which made failures …

### DIFF
--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -626,7 +626,7 @@ class GraphiteStatusCheck(StatusCheck):
                     raise Exception(u'Check type %s not supported' %
                                     self.check_type)
 
-                if failure_value:
+                if not failure_value is None:
                     failures.append(failure_value)
 
             failed = True


### PR DESCRIPTION
…"pass" when they shouldn't have.