### PR TITLE
alerts plugin css fix

### DIFF
--- a/cabot/templates/cabotapp/_service_list.html
+++ b/cabot/templates/cabotapp/_service_list.html
@@ -33,15 +33,16 @@
             <span class="label label-{% if service.inactive_status_checks.all.count > 0 %}warning{% else %}default{% endif %}">{{ service.inactive_status_checks.all.count }}</span>
           </td>
           <td>
-        {% if service.overall_status != service.PASSING_STATUS %}
-  <div class="col-xs-12 alert alert-warning">
+  {% if service.overall_status != service.PASSING_STATUS %}
+{#  <div class="col-xs-12 alert alert-warning">#}
+  <div>
     <div class="row">
     {% if service.unexpired_acknowledgement %}
-      <div class="col-xs-4">
+      <div class="col-xs-10">
         <a href="{% url 'remove-acknowledgement' pk=service.id %}" class="btn btn-xs btn-warning btn-block"><i class="glyphicon glyphicon-play"></i> Re-enable alerts</a>
       </div>
     {% else %}
-      <div class="col-xs-4">
+      <div class="col-xs-10">
         <a class="btn btn-success btn-block btn-xs" href="{% url 'acknowledge-alert' pk=service.id %}"><i class="glyphicon glyphicon-pause"></i> Acknowledge alert</a>
       </div>
     {% endif %}


### PR DESCRIPTION
This will fix the css column for the new alert plugin
before:

![screen shot 2015-12-09 at 11 43 45](https://cloud.githubusercontent.com/assets/6414667/11684601/b134cb9a-9e6a-11e5-9177-da21c29cce8a.png)

after:

![screen shot 2015-12-09 at 11 44 41](https://cloud.githubusercontent.com/assets/6414667/11684617/c910a4d2-9e6a-11e5-9b36-ebc979e2349d.png)
