### PR TITLE
pagination and search for instances and checks

### DIFF
--- a/cabot/cabotapp/forms.py
+++ b/cabot/cabotapp/forms.py
@@ -1,0 +1,5 @@
+from django import forms
+
+class HostSearchForm(forms.Form):
+    name = forms.CharField(required=False)
+

--- a/cabot/cabotapp/utils.py
+++ b/cabot/cabotapp/utils.py
@@ -1,0 +1,32 @@
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger, Page
+
+class Page2(Page):
+
+    def has_next2(self):
+        return self.number + 1 < self.paginator.num_pages
+
+    def has_next3(self):
+        return self.number + 2 < self.paginator.num_pages
+
+    def has_previous2(self):
+        return self.number > 2
+
+    def has_previous3(self):
+        return self.number > 3
+
+    def next_page_number2(self):
+        return self.paginator.validate_number(self.number + 2)
+
+    def next_page_number3(self):
+        return self.paginator.validate_number(self.number + 3)
+
+    def previous_page_number2(self):
+        return self.paginator.validate_number(self.number - 2)
+
+    def previous_page_number3(self):
+        return self.paginator.validate_number(self.number - 3)
+
+
+class Paginator2(Paginator):
+    def _get_page(self, *args, **kwargs):
+        return Page2(*args, **kwargs)

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -487,9 +487,61 @@ class JenkinsCheckUpdateView(CheckUpdateView):
 class StatusCheckListView(LoginRequiredMixin, ListView):
     model = StatusCheck
     context_object_name = 'checks'
+    template_name = 'cabotapp/statuscheck_list.html'
+    form = HostSearchForm
 
-    def get_queryset(self):
-        return StatusCheck.objects.all().order_by('name').prefetch_related('service_set', 'instance_set')
+    def get(self, request):
+        data = StatusCheck.objects.all().order_by('name')
+        if data:
+            paginator = Paginator2(data, 20)
+            page = request.GET.get('page')
+
+            try:
+                records = paginator.page(page)
+            except PageNotAnInteger:
+                records = paginator.page(1)
+            except EmptyPage:
+                records = paginator.page(paginator.num_pages)
+
+            return render(request, self.template_name, {'checks': records, 'form': self.form})
+        else:
+            return render(request, self.template_name, {'form': self.form})
+
+
+class StatusCheckSearchView(LoginRequiredMixin, ListView):
+    model = StatusCheck
+    context_object_name = 'checks'
+    template_name = 'cabotapp/statuscheck_list.html'
+    form = HostSearchForm
+
+    def get(self, request, name=None):
+        data = StatusCheck.objects.filter(name__icontains=name).order_by('name')
+        if data:
+            paginator = Paginator2(data, 20)
+            page = request.GET.get('page')
+
+            try:
+                records = paginator.page(page)
+            except PageNotAnInteger:
+                records = paginator.page(1)
+            except EmptyPage:
+                records = paginator.page(paginator.num_pages)
+
+            return render(request, self.template_name, {'checks': records, 'form': self.form})
+        else:
+            return redirect('checks')
+
+
+def StatusCheckSearchViewFBV(request, name=None):
+    if request.method == 'GET':
+        form = HostSearchForm(request.GET)
+        if form.is_valid():
+            name = form.cleaned_data['name']
+            return redirect('checks_search', name=name)
+        else:
+            return redirect('checks')
+    else:
+        return redirect('checks')
 
 
 class StatusCheckDeleteView(LoginRequiredMixin, DeleteView):
@@ -587,10 +639,25 @@ class InstanceListView(LoginRequiredMixin, ListView):
 
     model = Instance
     context_object_name = 'instances'
+    template_name = 'cabotapp/instance_list.html'
+    form = HostSearchForm
 
-    def get_queryset(self):
-        return Instance.objects.all().order_by('name').prefetch_related('status_checks')
+    def get(self, request):
+        data = Instance.objects.all().order_by('name')
+        if data:
+            paginator = Paginator2(data, 20)
+            page = request.GET.get('page')
 
+            try:
+                records = paginator.page(page)
+            except PageNotAnInteger:
+                records = paginator.page(1)
+            except EmptyPage:
+                records = paginator.page(paginator.num_pages)
+
+            return render(request, self.template_name, {'instances': records, 'form': self.form})
+        else:
+            return render(request, self.template_name, {'form': self.form})
 
 class InstanceSearchView(LoginRequiredMixin, ListView):
     model = Instance
@@ -621,11 +688,7 @@ def SearchViewFBV(request, name=None):
         form = HostSearchForm(request.GET)
         if form.is_valid():
             name = form.cleaned_data['name']
-            try:
-                instance = Instance.objects.get(name=name)
-                return redirect('instance', pk=instance.pk)
-            except Instance.DoesNotExist:
-                return redirect('instances_search', name=name)
+            return redirect('instances_search', name=name)
         else:
             return redirect('instances')
     else:

--- a/cabot/templates/cabotapp/_statuscheck_list.html
+++ b/cabot/templates/cabotapp/_statuscheck_list.html
@@ -23,6 +23,11 @@
   </div>
 </div>
 <hr>
+
+{% if checks_type == "All" %}
+{% include 'cabotapp/statuscheck_search_form.html' %}
+{% endif %}
+
 <div class="row">
   <div class="col-xs-12">
     {% if not checks %}

--- a/cabot/templates/cabotapp/instance_list.html
+++ b/cabot/templates/cabotapp/instance_list.html
@@ -10,7 +10,78 @@
     </div>
   </div>
   <div class="col-xs-12">
+
+    <form name="form1" action="{% url 'instance_info' name=name %}" method="GET" class="form-horizontal">
+{#      {% csrf_token %}#}
+      <div class="form-group">
+        <div class="col-sm-5">
+          <input type="text" name="name" class="form-control" id="hostname" placeholder="Pick a host">
+        </div>
+
+        <div class="span7 text-left">
+          <input class="btn btn-info btn-group-sm" type="submit" name="submit" value="Submit">
+        </div>
+      </div>
+    </form>
+
+
     {% include 'cabotapp/_instance_list.html' %}
+
+
+    <div class="pagination pagination-centered">
+
+    <div class="row-fluid">
+        <div class="span12">
+            <ul class="pagination pull-right">
+
+                {% if instances.number != 1 %}
+                    <li><a href="?page=1">← First</a></li>
+                {% else %}
+                    <li class="disabled"><a>← First</a></li>
+                {% endif %}
+
+                {% if instances.has_previous3 %}
+                    <li><a href="?page={{ instances.previous_page_number3 }}"> {{ instances.previous_page_number3 }} </a></li>
+                {% endif %}
+
+                {% if instances.has_previous2 %}
+                    <li><a href="?page={{ instances.previous_page_number2 }}"> {{ instances.previous_page_number2 }} </a></li>
+                {% endif %}
+
+                {% if instances.has_previous %}
+                    <li><a href="?page={{ instances.previous_page_number }}"> {{ instances.previous_page_number }} </a></li>
+                {% endif %}
+
+                <li class="active"><a href="#"> {{ instances.number }} </a></li>
+
+                {% if instances.has_next %}
+                    <li><a href="?page={{ instances.next_page_number }}"> {{ instances.next_page_number }} </a></li>
+                {% endif %}
+
+                {% if instances.has_next2 %}
+                    <li><a href="?page={{ instances.next_page_number2 }}"> {{ instances.next_page_number2 }} </a></li>
+                {% endif %}
+
+
+                {% if instances.has_next3 %}
+                    <li><a href="?page={{ instances.next_page_number3 }}"> {{ instances.next_page_number3 }} </a></li>
+                {% endif %}
+
+                {% if instances.number == instances.paginator.num_pages %}
+                    <li class="disabled"><a>Last → </a></li>
+                {% else %}
+                    <li><a href="?page={{ instances.paginator.num_pages }}">Last → </a></li>
+                {% endif %}
+
+            </ul>
+        </div>
+    <div class="span1">Showing {{ instances.number }} of {{ instances.paginator.num_pages }} entries</div>
+    </div>
+
+    </div>
+
+
+
   </div>
 </div>
 {% endblock content %}

--- a/cabot/templates/cabotapp/statuscheck_list.html
+++ b/cabot/templates/cabotapp/statuscheck_list.html
@@ -57,20 +57,3 @@
 </div>
 
 {% endblock content %}
-
-{#{% block js %}#}
-{#{% load compress %}#}
-{#{{ block.super }}#}
-{#{% compress js %}#}
-{#<script type="text/coffeescript">#}
-{#  $('.datatable').dataTable#}
-{#    sDom: "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span12'i><'span12 center'p>>"#}
-{#    sPaginationType: "bootstrap"#}
-{#    iDisplayLength: 100#}
-{#    oLanguage:#}
-{#      sLengthMenu: "_MENU_ records per page"#}
-{#    fnDrawCallback: () ->#}
-{#      $('.sparktristate').sparkline('html', {type: 'tristate'})#}
-{#</script>#}
-{#{% endcompress %}#}
-{#{% endblock js %}#}

--- a/cabot/templates/cabotapp/statuscheck_list.html
+++ b/cabot/templates/cabotapp/statuscheck_list.html
@@ -4,21 +4,73 @@
 
 {% include 'cabotapp/_statuscheck_list.html' with checks_type="All" %}
 
+    <div class="pagination pagination-centered">
+
+    <div class="row-fluid">
+        <div class="span12">
+            <ul class="pagination pull-right">
+
+                {% if checks.number != 1 %}
+                    <li><a href="?page=1">← First</a></li>
+                {% else %}
+                    <li class="disabled"><a>← First</a></li>
+                {% endif %}
+
+                {% if checks.has_previous3 %}
+                    <li><a href="?page={{ checks.previous_page_number3 }}"> {{ checks.previous_page_number3 }} </a></li>
+                {% endif %}
+
+                {% if checks.has_previous2 %}
+                    <li><a href="?page={{ checks.previous_page_number2 }}"> {{ checks.previous_page_number2 }} </a></li>
+                {% endif %}
+
+                {% if checks.has_previous %}
+                    <li><a href="?page={{ checks.previous_page_number }}"> {{ checks.previous_page_number }} </a></li>
+                {% endif %}
+
+                <li class="active"><a href="#"> {{ checks.number }} </a></li>
+
+                {% if checks.has_next %}
+                    <li><a href="?page={{ checks.next_page_number }}"> {{ checks.next_page_number }} </a></li>
+                {% endif %}
+
+                {% if checks.has_next2 %}
+                    <li><a href="?page={{ checks.next_page_number2 }}"> {{ checks.next_page_number2 }} </a></li>
+                {% endif %}
+
+
+                {% if checks.has_next3 %}
+                    <li><a href="?page={{ checks.next_page_number3 }}"> {{ checks.next_page_number3 }} </a></li>
+                {% endif %}
+
+                {% if checks.number == checks.paginator.num_pages %}
+                    <li class="disabled"><a>Last → </a></li>
+                {% else %}
+                    <li><a href="?page={{ checks.paginator.num_pages }}">Last → </a></li>
+                {% endif %}
+
+            </ul>
+        </div>
+    <div class="span1">Showing {{ checks.number }} of {{ checks.paginator.num_pages }} entries</div>
+    </div>
+
+</div>
+
 {% endblock content %}
 
-{% block js %}
-{% load compress %}
-{{ block.super }}
-{% compress js %}
-<script type="text/coffeescript">
-  $('.datatable').dataTable
-    sDom: "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span12'i><'span12 center'p>>"
-    sPaginationType: "bootstrap"
-    iDisplayLength: 100
-    oLanguage:
-      sLengthMenu: "_MENU_ records per page"
-    fnDrawCallback: () ->
-      $('.sparktristate').sparkline('html', {type: 'tristate'})
-</script>
-{% endcompress %}
-{% endblock js %}
+{#{% block js %}#}
+{#{% load compress %}#}
+{#{{ block.super }}#}
+{#{% compress js %}#}
+{#<script type="text/coffeescript">#}
+{#  $('.datatable').dataTable#}
+{#    sDom: "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span12'i><'span12 center'p>>"#}
+{#    sPaginationType: "bootstrap"#}
+{#    iDisplayLength: 100#}
+{#    oLanguage:#}
+{#      sLengthMenu: "_MENU_ records per page"#}
+{#    fnDrawCallback: () ->#}
+{#      $('.sparktristate').sparkline('html', {type: 'tristate'})#}
+{#</script>#}
+{#{% endcompress %}#}
+{#{% endblock js %}#}

--- a/cabot/templates/cabotapp/statuscheck_search_form.html
+++ b/cabot/templates/cabotapp/statuscheck_search_form.html
@@ -1,0 +1,12 @@
+<form name="form1" action="{% url 'checks_info' name=name %}" method="GET" class="form-horizontal">
+{#      {% csrf_token %}#}
+
+    <div class="form-group">
+        <div class="col-sm-5">
+            <input type="text" name="name" class="form-control" id="hostname" placeholder="Pick a check">
+        </div>
+        <div class="span7 text-left">
+            <input class="btn btn-info btn-group-sm" type="submit" name="submit" value="Submit">
+        </div>
+    </div>
+</form>

--- a/cabot/urls.py
+++ b/cabot/urls.py
@@ -15,7 +15,7 @@ from cabot.cabotapp.views import (InstanceListView, InstanceDetailView,
     InstanceUpdateView, InstanceCreateView, InstanceDeleteView,
     ServiceListView, ServiceDetailView,
     ServiceUpdateView, ServiceCreateView, ServiceDeleteView,
-    UserProfileUpdateView, ShiftListView, subscriptions)
+    UserProfileUpdateView, ShiftListView, subscriptions, InstanceSearchView, StatusCheckSearchView)
 
 from cabot import rest_urls
 
@@ -144,6 +144,15 @@ urlpatterns = patterns('',
      url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
 
      url(r'^api/', include(rest_urls.router.urls)),
+
+     url(r'^instanceinfo/(?P<name>.*)/', 'cabot.cabotapp.views.SearchViewFBV', name='instance_info'),
+
+     url(r'^instancesearch/(?P<name>.*)/', view=InstanceSearchView.as_view(), name='instances_search'),
+
+     url(r'^checksinfo/(?P<name>.*)/', 'cabot.cabotapp.views.StatusCheckSearchViewFBV', name='checks_info'),
+
+     url(r'^checkssearch/(?P<name>.*)/', view=StatusCheckSearchView.as_view(), name='checks_search'),
+
      )
 
 def append_plugin_urls():


### PR DESCRIPTION
If you have a lot of instances with a lot of checks this will significantly reduce the time instance.html and checks.html loads. With added search field it will make some tasks faster.
There is a js pagination for checks right now but this will still load all objects from postgresql and then paginate on the fly thus time consuming

![screen shot 2015-12-11 at 16 28 33](https://cloud.githubusercontent.com/assets/6414667/11749359/27f8fc86-a025-11e5-95db-9bb61b4e7b13.png)

![screen shot 2015-12-11 at 16 28 57](https://cloud.githubusercontent.com/assets/6414667/11749365/2babd3c6-a025-11e5-8519-fcb4529266b9.png)

![screen shot 2015-12-11 at 16 28 48](https://cloud.githubusercontent.com/assets/6414667/11749367/2f8a6b6a-a025-11e5-86d1-d4992c08df20.png)

