### PR TITLE
Add check for "green" status for Hudson

### DIFF
--- a/cabot/cabotapp/jenkins.py
+++ b/cabot/cabotapp/jenkins.py
@@ -23,7 +23,7 @@ def get_job_status(jobname):
     status = resp.json()
     ret['status_code'] = resp.status_code
     ret['job_number'] = status['lastBuild'].get('number', None)
-    if status['color'].startswith('blue'):
+    if status['color'].startswith('blue') or status['color'].startswith('green'): # Jenkins uses "blue" for successful; Hudson uses "green"
         ret['active'] = True
         ret['succeeded'] = True
     elif status['color'] == 'disabled':


### PR DESCRIPTION
Hudson and Jenkins have extremely similar APIs, one of the main differences is that Jenkins uses "blue" but Hudson uses "green" for a successful last build.  Adding the option to check for "green" status allows the Jenkins checks to also work for checking Hudson jobs.

Jenkins does not use green as a color: https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/BallColor.java