### PR TITLE
Automatically create UserProfiles

### DIFF
--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models.signals import post_save
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from polymorphic import PolymorphicModel
@@ -913,6 +914,11 @@ class UserProfile(models.Model):
     hipchat_alias = models.CharField(max_length=50, blank=True, default='')
     fallback_alert_user = models.BooleanField(default=False)
 
+def create_user_profile(sender, instance, created, **kwargs):
+    if created:
+        UserProfile.objects.create(user=instance)
+
+post_save.connect(create_user_profile, sender=User)
 
 class Shift(models.Model):
     start = models.DateTimeField()

--- a/cabot/cabotapp/tests/tests_basic.py
+++ b/cabot/cabotapp/tests/tests_basic.py
@@ -23,7 +23,7 @@ from mock import Mock, patch
 from cabot.cabotapp.models import (
     GraphiteStatusCheck, JenkinsStatusCheck,
     HttpStatusCheck, ICMPStatusCheck, Service, Instance,
-    StatusCheckResult, UserProfile, minimize_targets)
+    StatusCheckResult, minimize_targets)
 from cabot.cabotapp.views import StatusCheckReportForm
 from cabot.cabotapp.alert import send_alert
 from cabot.cabotapp.graphite import parse_metric
@@ -877,10 +877,8 @@ class TestAlerts(LocalTestCase):
     def setUp(self):
         super(TestAlerts, self).setUp()
 
-        self.user_profile = UserProfile.objects.create(
-            user = self.user,
-            hipchat_alias = "test_user_hipchat_alias",)
-        self.user_profile.save()
+        self.user.profile.hipchat_alias = "test_user_hipchat_alias"
+        self.user.profile.save()
 
         self.service.users_to_notify.add(self.user)
         self.service.update_status()


### PR DESCRIPTION
I'm trying to use the cabot-alert-pagerduty plugin and found that it
expects all users to have profiles. I think that's a pretty reasonable
assumption, so here's a change that automatically creates profiles
when new users are created using the post_save signal.