### PR TITLE
Expose the User API if enabled in the settings file

### DIFF
--- a/cabot/rest_urls.py
+++ b/cabot/rest_urls.py
@@ -145,8 +145,6 @@ if settings.EXPOSE_USER_API:
         arg_model=models.UserProfile,
         arg_fields=(
             'user',
-            'mobile_number',
-            'hipchat_alias',
             'fallback_alert_user',
         ),
     ))

--- a/cabot/rest_urls.py
+++ b/cabot/rest_urls.py
@@ -1,4 +1,5 @@
 from django.db import models as model_fields
+from django.conf import settings
 from django.conf.urls import url, include
 from django.contrib.auth import models as django_models
 from polymorphic import PolymorphicModel
@@ -124,33 +125,32 @@ router.register(r'jenkins_checks', create_viewset(
     ),
 ))
 
-'''
-Omitting user API, could expose/allow modifying dangerous fields.
+# User API is off by default, could expose/allow modifying dangerous fields
+if settings.EXPOSE_USER_API:
+    router.register(r'users', create_viewset(
+        arg_model=django_models.User,
+        arg_fields=(
+            'password',
+            'is_active',
+            'groups',
+            #'user_permissions', # Doesn't work, removing for now
+            'username',
+            'first_name',
+            'last_name',
+            'email',
+        ),
+    ))
 
-router.register(r'users', create_viewset(
-    arg_model=django_models.User,
-    arg_fields=(
-        'password',
-        'is_active',
-        'groups',
-        #'user_permissions', # Doesn't work, removing for now
-        'username',
-        'first_name',
-        'last_name',
-        'email',
-    ),
-))
+    router.register(r'user_profiles', create_viewset(
+        arg_model=models.UserProfile,
+        arg_fields=(
+            'user',
+            'mobile_number',
+            'hipchat_alias',
+            'fallback_alert_user',
+        ),
+    ))
 
-router.register(r'user_profiles', create_viewset(
-    arg_model=models.UserProfile,
-    arg_fields=(
-        'user',
-        'mobile_number',
-        'hipchat_alias',
-        'fallback_alert_user',
-    ),
-))
-'''
 
 router.register(r'shifts', create_viewset(
     arg_model=models.Shift,

--- a/cabot/settings.py
+++ b/cabot/settings.py
@@ -244,3 +244,5 @@ AUTH_LDAP = os.environ.get('AUTH_LDAP', 'false')
 if AUTH_LDAP.lower() == "true":
     from settings_ldap import *
     AUTHENTICATION_BACKENDS += tuple(['django_auth_ldap.backend.LDAPBackend'])
+
+EXPOSE_USER_API = os.environ.get('EXPOSE_USER_API', False)


### PR DESCRIPTION
I'm using the awesome API to automatically create alerts from SaltStack,
and I'm finding the need to lookup users. I found you already had the
code in place, but it was commented out. I'm leaving it off by default,
but am providing a settings option to turn it on.

@dbuxton another one for you :)