### PR TITLE
safely handle assigning "json" raw_data from results

### DIFF
--- a/cabot/templates/cabotapp/statuscheckresult_detail.html
+++ b/cabot/templates/cabotapp/statuscheckresult_detail.html
@@ -31,7 +31,11 @@
 {% load compress %}
 {{ block.super }}
 <script type="text/javascript">
-window.DATA = {{ result.raw_data|safe }};
+try {
+  window.DATA = JSON.parse("{{ result.raw_data|escapejs }}");
+} catch (e) {
+  window.DATA = {};
+}
 </script>
 {% compress js %}
 <script type="text/javascript" src="{{ STATIC_URL }}arachnys/js/raphael.js"></script>


### PR DESCRIPTION
the way that raw data was handled before meant that injection could be possible
for XSS or just general page breakage when assigning the raw data from the result
onto the window DATA variable.

this change makes it so we parse the value as an escapes JS string value, and on
failure assigns an empty object

this does mean that instead of the original behavior of failing with a JS error
on non-valid JSON data we instead create an empty object into window.DATA

fixes #231