### PR TITLE
Configurable URL prefix

### DIFF
--- a/cabot/cabotapp/tests/test_urlprefix.py
+++ b/cabot/cabotapp/tests/test_urlprefix.py
@@ -1,0 +1,86 @@
+import sys
+
+from django.core.urlresolvers import reverse, clear_url_caches
+from django.conf import settings
+from django.test.utils import override_settings
+from django.utils.importlib import import_module
+
+from rest_framework import status, HTTP_HEADER_ENCODING
+
+from tests_basic import LocalTestCase
+
+class override_urlprefix(override_settings):
+    def clear_cache(self):
+        # If we don't do this, nothing gets correctly set for the URL Prefix
+        urlconf = settings.ROOT_URLCONF
+        if urlconf in sys.modules:
+            reload(sys.modules[urlconf])
+        import_module(urlconf)
+
+        # Don't forget to clear out the cache for `reverse`
+        clear_url_caches()
+
+    def __init__(self, urlprefix):
+        urlprefix = urlprefix.rstrip("/")
+
+        # Have to turn off the compressor here, can't find a way to reload
+        # the COMPRESS_URL into it on the fly
+
+        super(override_urlprefix, self).__init__(
+            URL_PREFIX = urlprefix,
+            MEDIA_URL = "%s/media/" % urlprefix,
+            STATIC_URL = "%s/static/" % urlprefix,
+            COMPRESS_URL = "%s/static/" % urlprefix,
+            COMPRESS_ENABLED = False
+        )
+
+    def __enter__(self):
+        super(override_urlprefix, self).__enter__()
+        self.clear_cache()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super(override_urlprefix, self).__exit__(exc_type, exc_value, traceback)
+        self.clear_cache()
+
+class URLPrefixTestCase(LocalTestCase):
+    def set_url_prefix(self, prefix):
+        return override_urlprefix(prefix)
+
+    def test_reverse(self):
+        prefix = '/test'
+        before = reverse('services')
+
+        with self.set_url_prefix(prefix):
+            self.assertNotEqual(reverse('services'), before)
+            self.assertTrue(reverse('services').startswith(prefix))
+            self.assertEqual(reverse('services')[len(prefix):], before)
+
+    def test_loginurl(self):
+        prefix = '/test'
+
+        with self.set_url_prefix(prefix):
+            loginurl = str(settings.LOGIN_URL)
+            response = self.client.get(reverse('services'))
+
+            self.assertTrue(loginurl.startswith(prefix))
+            self.assertTrue(loginurl in response.url)
+
+    def test_query(self):
+        prefix = '/test'
+
+        self.client.login(username=self.username, password=self.password)
+
+        before_services = self.client.get(reverse('services'))
+        before_systemstatus = self.client.get(reverse('system-status'))
+
+        with self.set_url_prefix(prefix):
+            response = self.client.get(reverse('services'))
+
+            self.assertEqual(response.status_code, before_services.status_code)
+            self.assertNotEqual(response.content, before_services.content)
+
+            self.assertIn(reverse('services'), response.content)
+
+            resposnse = self.client.get(reverse('system-status'))
+
+            self.assertEqual(response.status_code, before_systemstatus.status_code)

--- a/cabot/settings.py
+++ b/cabot/settings.py
@@ -2,6 +2,7 @@ import os
 import dj_database_url
 import re
 from django.conf import settings
+from django.core.urlresolvers import reverse_lazy
 from cabot.celeryconfig import *
 from cabot.cabot_config import *
 
@@ -20,6 +21,8 @@ DATABASES = {'default': dj_database_url.parse(os.environ["DATABASE_URL"])}
 
 if not DEBUG:
     DATABASES['default']['OPTIONS'] = {'autocommit': True}
+
+LOGIN_URL = reverse_lazy('login')
 
 USE_TZ = True
 

--- a/cabot/settings.py
+++ b/cabot/settings.py
@@ -22,6 +22,8 @@ DATABASES = {'default': dj_database_url.parse(os.environ["DATABASE_URL"])}
 if not DEBUG:
     DATABASES['default']['OPTIONS'] = {'autocommit': True}
 
+URL_PREFIX = os.environ.get('URL_PREFIX', '/').rstrip("/")
+
 LOGIN_URL = reverse_lazy('login')
 
 USE_TZ = True
@@ -58,7 +60,7 @@ MEDIA_ROOT = os.path.join(PROJECT_ROOT, 'media/')
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.
 # Examples: "http://media.lawrence.com/media/", "http://example.com/media/"
-MEDIA_URL = '/media/'
+MEDIA_URL = '%s/media/' % URL_PREFIX
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files
@@ -70,7 +72,7 @@ COMPRESS_ROOT = STATIC_ROOT
 
 # URL prefix for static files.
 # Example: "http://media.lawrence.com/static/"
-STATIC_URL = '/static/'
+STATIC_URL = '%s/static/' % URL_PREFIX
 
 # Additional locations of static files
 STATICFILES_DIRS = [os.path.join(PROJECT_ROOT, 'static')]
@@ -153,7 +155,7 @@ EMAIL_USE_TLS = os.environ.get('SES_USE_TLS', 0)
 
 COMPRESS_OFFLINE = not DEBUG
 
-COMPRESS_URL = '/static/'
+COMPRESS_URL = '%s/static/' % URL_PREFIX
 
 RECOVERY_SNIPPETS_WHITELIST = (
     r'https?://[^.]+\.hackpad\.com/[^./]+\.js',

--- a/cabot/templates/base.html
+++ b/cabot/templates/base.html
@@ -90,15 +90,15 @@
             <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="download">{{ user.username }} <span class="caret"></span></a>
             <ul class="dropdown-menu" aria-labelledby="admin">
               <li>
-                <a href="/admin/auth/user/add/"><i class="glyphicon glyphicon-user"></i> Add user</a>
+                <a href="{% url "admin:auth_user_add" %}"><i class="glyphicon glyphicon-user"></i> Add user</a>
               </li>
               <li class="divider"></li>
               <li>
-                <a href="/admin/"><i class="glyphicon glyphicon-lock"></i> Django admin</a>
+                <a href="{% url "admin:index" %}"><i class="glyphicon glyphicon-lock"></i> Django admin</a>
               </li>
               <li class="divider"></li>
               <li>
-                <a href="/accounts/logout/"><i class="glyphicon glyphicon-log-out"></i> Log out</a>
+                <a href="{% url "logout" %}"><i class="glyphicon glyphicon-log-out"></i> Log out</a>
               </li>
             </ul>
           </li>

--- a/cabot/urls.py
+++ b/cabot/urls.py
@@ -165,3 +165,8 @@ def append_plugin_urls():
                 )
 
 append_plugin_urls()
+
+if settings.URL_PREFIX.strip('/'):
+    urlpatterns = patterns('',
+        ('^%s/' % settings.URL_PREFIX.strip('/'), include(urlpatterns))
+    )

--- a/cabot/urls.py
+++ b/cabot/urls.py
@@ -30,6 +30,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 urlpatterns = patterns('',
+     # for the password reset views
+     url('^', include('django.contrib.auth.urls')),
+
      url(r'^$', view=RedirectView.as_view(url='services/', permanent=False),
              name='dashboard'),
      url(r'^subscriptions/', view=subscriptions,
@@ -139,9 +142,6 @@ urlpatterns = patterns('',
                 ), name='update-alert-user-data'),
 
      url(r'^admin/', include(admin.site.urls)),
-
-     # for the password reset views
-     url('^', include('django.contrib.auth.urls')),
 
      # Comment below line to disable browsable rest api
      url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),

--- a/conf/development.env.example
+++ b/conf/development.env.example
@@ -10,6 +10,9 @@ PORT=5001
 
 # You shouldn't need to change anything above this line
 
+# Base path to include before generated URLs.  If not defined, uses `/`
+# URL_PREFIX=/
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 TIME_ZONE=Etc/UTC

--- a/conf/production.env.example
+++ b/conf/production.env.example
@@ -10,6 +10,9 @@ VENV=/home/ubuntu/venv
 
 # You shouldn't need to change anything above this line
 
+# Base path to include before generated URLs.  If not defined, uses `/`
+# URL_PREFIX=/
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 TIME_ZONE=Etc/UTC


### PR DESCRIPTION
This is a basic implementation to allow the usage of a URL prefix with Cabot, as well as some bug fixes related to the feature.

* Hard-coded Static URLs in templates have been replaced with `{% url "" $}` equivalents
* the `LOGIN_URL` django settings value is set correctly from the `urls.py`
* the URL overriding is updated so we replace django URLs with our own
* add a `URL_PREFIX` environment variable to configure the URL prefix applied to all generated URLs

This resolves #321 and I'm pretty certain it works well enough for me to use Cabot under a reverse proxy in a subdirectory.

However, I have not tested all of the plugins, and I'm not the greatest with Django, so a second set of eyes would be appreciated!