### PR TITLE
Remove distribute hard-coded version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         'argparse==1.2.1',
         'billiard==3.3.0.13',
         'celery==3.1.7',
-        'distribute==0.6.24',
         'dj-database-url==0.2.2',
         'django-appconf==0.6',
         'django-celery==3.1.1',


### PR DESCRIPTION
Distribute is not used within the project, so it should not be a  part of the setup.py requirements. 

There should not be a situation where it is required to be hard-coded like that. If there is due to some distribute bug referencing other deployment options used by your company - it should be set as minimal version rather than set version given that you would use setup.py based on your company setup rather than leaving project clean.