### PR TITLE
Add a delay in updateGraphiteData before making the backend call

### DIFF
--- a/cabot/templates/cabotapp/statuscheck_form.html
+++ b/cabot/templates/cabotapp/statuscheck_form.html
@@ -36,7 +36,11 @@ GRAPHITE_ENDPOINT = '/graphite/'
 
 $(document).ready ->
   updateGraphiteData()
-  $('#id_metric').on('keyup', updateGraphiteData)
+  $('#id_metric').on('keyup', complete)
+
+  complete = () ->
+      clearTimeout(timer)
+      timer = setTimeout(updateGraphiteData, 1000)
 
   $('#id_metric').autocomplete
     source: (request, response) ->


### PR DESCRIPTION
Cabot seems to be making a backend call for each keypress when checking the metric values. This was bugging me, so  just added a delayed timeout to smooth this out a bit.

This this change, we'll be making less backend calls when updating metrics (hopefully enough time for the user to finish the metrics they were hoping to create the alert on)