### PR TITLE
No backend call in case there is no change

### DIFF
--- a/cabot/templates/cabotapp/statuscheck_form.html
+++ b/cabot/templates/cabotapp/statuscheck_form.html
@@ -54,9 +54,14 @@ $(document).ready ->
       if $('#id_metric').is(':focus')
         $('#id_metric').autocomplete("search", $('#id_metric').val())
 
+previousTerm = undefined
+
 updateGraphiteData = () ->
-  $('#graphite_data_container').text 'Getting data'
   m = $('#id_metric').val()
+  if !m or previousTerm == m
+    return
+  previousTerm = m
+  $('#graphite_data_container').text 'Getting data'
   $.ajax
     url: GRAPHITE_ENDPOINT
     data:


### PR DESCRIPTION
Another area I saw where no backend call was required. This happens to me as I'm trying to just navigate on the metrics text box without changing the content (metric name)