### PR TITLE
Use graphite timestamps properly

### DIFF
--- a/cabot/cabotapp/graphite.py
+++ b/cabot/cabotapp/graphite.py
@@ -10,13 +10,19 @@ graphite_from = settings.GRAPHITE_FROM
 auth = (user, password)
 
 
-def get_data(target_pattern):
+def get_data(target_pattern, mins_to_check=None):
+
+    if mins_to_check:
+        _from = '-%dminute' % mins_to_check
+    else:
+        _from = graphite_from
+
     resp = requests.get(
         graphite_api + 'render', auth=auth,
         params={
             'target': target_pattern,
             'format': 'json',
-            'from': graphite_from,
+            'from': _from,
         }
     )
     resp.raise_for_status()
@@ -72,7 +78,7 @@ def parse_metric(metric, mins_to_check=5, utcnow=None):
         'series': [],
     }
     try:
-        data = get_data(metric)
+        data = get_data(metric, mins_to_check)
     except requests.exceptions.RequestException, e:
         ret['error'] = 'Error getting data from Graphite: %s' % e
         ret['raw'] = ret['error']

--- a/cabot/cabotapp/graphite.py
+++ b/cabot/cabotapp/graphite.py
@@ -60,14 +60,6 @@ def get_all_metrics(limit=None):
 
 
 def parse_metric(metric, mins_to_check=5, utcnow=None):
-    """
-    Returns dict with:
-    - num_series_with_data: Number of series with data
-    - num_series_no_data: Number of total series
-    - max
-    - min
-    - average_value
-    """
     if utcnow is None:
         utcnow = time.time()
     ret = {

--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -640,7 +640,15 @@ class GraphiteStatusCheck(StatusCheck):
         result = StatusCheckResult(check=self)
 
         failures = []
-        graphite_output = parse_metric(self.metric, mins_to_check=self.frequency, utcnow=self.utcnow)
+
+        last_result = self.last_result()
+        if last_result:
+            last_result_started = last_result.time
+            time_to_check = max(self.frequency, ((timezone.now() - last_result_started).total_seconds() / 60))
+        else:
+            time_to_check = self.frequency
+
+        graphite_output = parse_metric(self.metric, mins_to_check=time_to_check, utcnow=self.utcnow)
 
         try:
             result.raw_data = json.dumps(graphite_output['raw'])

--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -612,6 +612,7 @@ def minimize_targets(targets):
 
 
 class GraphiteStatusCheck(StatusCheck):
+
     class Meta(StatusCheck.Meta):
         proxy = True
 
@@ -634,10 +635,12 @@ class GraphiteStatusCheck(StatusCheck):
             return "%s %s %0.1f" % (value, self.check_type, float(self.value))
 
     def _run(self):
+        if not hasattr(self, 'utcnow'):
+            self.utcnow = None
         result = StatusCheckResult(check=self)
 
         failures = []
-        graphite_output = parse_metric(self.metric, mins_to_check=self.frequency)
+        graphite_output = parse_metric(self.metric, mins_to_check=self.frequency, utcnow=self.utcnow)
 
         try:
             result.raw_data = json.dumps(graphite_output['raw'])

--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -644,7 +644,7 @@ class GraphiteStatusCheck(StatusCheck):
         last_result = self.last_result()
         if last_result:
             last_result_started = last_result.time
-            time_to_check = max(self.frequency, ((timezone.now() - last_result_started).total_seconds() / 60))
+            time_to_check = max(self.frequency, ((timezone.now() - last_result_started).total_seconds() / 60) + 1)
         else:
             time_to_check = self.frequency
 

--- a/cabot/cabotapp/tests/tests_basic.py
+++ b/cabot/cabotapp/tests/tests_basic.py
@@ -242,6 +242,7 @@ class TestCheckRun(LocalTestCase):
     def test_graphite_run(self):
         checkresults = self.graphite_check.statuscheckresult_set.all()
         self.assertEqual(len(checkresults), 2)
+        self.graphite_check.utcnow = 1387818601 # see graphite_response.json for this magic timestamp
         self.graphite_check.run()
         checkresults = self.graphite_check.statuscheckresult_set.all()
         self.assertEqual(len(checkresults), 3)
@@ -291,8 +292,8 @@ class TestCheckRun(LocalTestCase):
 
     @patch('cabot.cabotapp.graphite.requests.get', fake_graphite_series_response)
     def test_graphite_series_run(self):
-        jsn = parse_metric('fake.pattern')
-        self.assertEqual(jsn['average_value'], 59.86)
+        jsn = parse_metric('fake.pattern', utcnow=1387818601)
+        self.assertLess(abs(jsn['average_value']-53.26), 0.1)
         self.assertEqual(jsn['series'][0]['max'], 151.0)
         self.assertEqual(jsn['series'][0]['min'], 0.1)
 

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -769,10 +769,14 @@ def jsonify(d):
 @login_required
 def graphite_api_data(request):
     metric = request.GET.get('metric')
+    if request.GET.get('frequency'):
+        mins_to_check = int(request.GET.get('frequency'))
+    else:
+        mins_to_check = None
     data = None
     matching_metrics = None
     try:
-        data = get_data(metric)
+        data = get_data(metric, mins_to_check)
     except requests.exceptions.RequestException, e:
         pass
     if not data:

--- a/cabot/templates/cabotapp/statuscheck_form.html
+++ b/cabot/templates/cabotapp/statuscheck_form.html
@@ -37,6 +37,7 @@ GRAPHITE_ENDPOINT = '/graphite/'
 $(document).ready ->
   updateGraphiteData()
   $('#id_metric').on('keyup', complete)
+  $('#id_frequency').on('keyup', complete)
 
   complete = () ->
       clearTimeout(timer)
@@ -62,6 +63,7 @@ previousTerm = undefined
 
 updateGraphiteData = () ->
   m = $('#id_metric').val()
+  f = $('#id_frequency').val()
   if !m or previousTerm == m
     return
   previousTerm = m
@@ -70,6 +72,7 @@ updateGraphiteData = () ->
     url: GRAPHITE_ENDPOINT
     data:
       metric: m
+      frequency: f
   .done (data) ->
     if data.data? and data.data.length? != 0
       $('#graphite_data_container').text JSON.stringify(data.data, undefined, 2)


### PR DESCRIPTION
@JeanFred interested in your thoughts on this.

Up to now we have just been assuming that datapoints sent back by Graphite are 1 minute apart. That isn't always true. That causes all sorts of annoying bugs.

This PR addresses that by:

* Asking Graphite for the last `GraphiteCheck.frequency` minutes of data in the first place (rather than just "whatever it has" - this obsoletes/plagiarizes #127)
* Actually using the timestamps on the Graphite data series to work out if they should be included in calculating a passing or failing status. (Broadly speaking, without worrying too much about execution time issues, a check should look at all the data since it was last run)

However, there is a potential issue in that you might have infrequently updated data that you want to watch like a hawk. Just say you have a metric pushed every 4 hours that is either 1 ("the building is on fire") or 0 ("the building is fine"). You might want to watch this every minute to make sure that as soon as an issue is spotted, it is alerted on.

What's not clear to me is whether or not Graphite will actually serve you any datapoints for infrequently updated metrics in a smaller (say 1 min) time window if the `frequency` is set to 1. Do you know?