### PR TITLE
Update development documentation for Docker/docker-compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: ruby
+rvm:
+- 2.1
+
+install: gem install jekyll html-proofer
+
+script:
+  - jekyll build
+  - htmlproofer ./_site
+
+branches:
+  only:
+  - gh-pages     # test the gh-pages branch
+
+env:
+  global:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+
+sudo: false # route your build to the container-based infrastructure for a faster build

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -48,7 +48,7 @@
                 <div class="row">
                     <div class="col-xs-12">
                         <div class="screenshot">
-                            <img class="img-responsive" src="/images/frontpage-screenshot.png"/>
+                            <img class="img-responsive" src="/images/frontpage-screenshot.png" alt="Application frontpage"/>
                         </div>
                     </div>
                 </div>

--- a/_posts/2014-01-08-get-started.md
+++ b/_posts/2014-01-08-get-started.md
@@ -16,24 +16,20 @@ order: 1
     $ vim conf/development.env
     # Edit settings - add Twilio, Hipchat etc
 
-    $ vagrant up
-    # start Vagrant and provision the virtual machine using bin/provision
+    $ docker-compose build
+    # Build the web and worker services
+    $ docker-compose run --rm web bash bin/build-app
+    # Prepare the application: create DB tables, apply migrations, collect assets
+    $ docker-compose run --rm web python manage.py createsuperuser
+    # Create the first user (as a super-user)
 
-    $ vagrant ssh
-    # log in to provisioned Vagrant box
-    
-    $ foreman run python manage.py syncdb --migrate
-    # Create DB tables and apply migrations
-    $ foreman start
-    # run webserver and celery tasks using Django dev server
-
-#### Running OSX?
-
-If you're on OSX there's a [guide to how to set up your development environment on OSX](https://gist.github.com/jirutka/8636572)contributed by [Jakub Jirutka](https://gist.github.com/jirutka).
+    $ docker-compose up -d
+    # Run webserver and Celery tasks using Django dev server
+    # You can access your dev instance at http://localhost:5001/
 
 ### Running tests
 
-    $ foreman run python manage.py test cabot
+    $ docker-compose run --rm web python manage.py test cabot
 
 Test coverage is currently pretty poor so any contributions are welcome.
 
@@ -41,7 +37,7 @@ Tests can be found in `cabot/cabotapp/tests/`. Currently using `Mock` for mockin
 
 ### Requirements
 
-*   [Vagrant](http://vagrantup.com)
-*   [Virtualbox](https://www.virtualbox.org)
+*   [Docker](https://www.docker.com/)
+*   [docker-compose](https://docs.docker.com/compose/)
 
-There's nothing to stop you developing locally without Vagrant but don't blame us if you get tangled.
+Please refer to the Docker documentation to install it on Mac, Windows or Linux.

--- a/_posts/2015-01-20-writing-alert-plugins.md
+++ b/_posts/2015-01-20-writing-alert-plugins.md
@@ -10,7 +10,7 @@ With the release of cabot 0.0.1-dev, Cabot can now be extended through the use o
 
 Before getting started, follow the [development introduction]({% post_url 2014-01-08-get-started %}). Continue when you have set up vagrant and got cabot running locally on your own machine. You should also be up to date on how to [install a plugin]({% post_url 2015-01-20-installing-alert-plugins %}).
 
-You can obtain a ['skeleton' alert plugin](https://github.com/arachnys/cabot-alert-skeleton) which has all the necessary files to get started with cabot plugin development.
+You can obtain a ['skeleton' alert plugin](https://github.com/cabotapp/cabot-alert-skeleton) which has all the necessary files to get started with cabot plugin development.
 
 The cabot plugin architecture is designed to give the full power of django to the developer by getting out of his/her way as much as possible. For this reason it is necessary to understand the basics of how a django application works.
 


### PR DESCRIPTION
We are moving away from Vagrant in favour of Docker/docker-compose
for local development environment of Cabot (see #314).