### PR TITLE
Add Flake8 linting using tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
  - curl -L https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
  - chmod +x docker-compose
  - sudo mv docker-compose /usr/local/bin
+ - sudo pip install tox
 
 # setup databases
 before_script:
@@ -18,4 +19,5 @@ before_script:
  - sleep 20
 
 script:
+ - tox
  - docker-compose run web python manage.py test cabot

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,40 @@
+[tox]
+envlist = config,flake8
+skipsdist = True
+
+[testenv:config]
+commands =
+    /bin/bash -c 'set -euo pipefail && . ./conf/production.env.example'
+    /bin/bash -c 'set -euo pipefail && . ./conf/development.env.example'
+
+[testenv:flake8]
+deps =
+	flake8
+	flake8-debugger
+commands = flake8 {posargs}
+
+[flake8]
+exclude = .venv,venv,.tox,dist,doc,build,*.egg,docs,setup.py,fabfile.py,*/migrations/
+ignore = E121,E123,E125,E126,E127,E128,E131,E222,E226,E231,E251,E261,E265,E302,E402,E714,F401,F403,F405,F841,W391
+max-line-length = 160
+# E121 continuation line under-indented for hanging indent
+# E123 closing bracket does not match indentation of opening bracket's line
+# E125 continuation line with same indent as next logical line
+# E126 continuation line over-indented for hanging indent
+# E127 continuation line over-indented for visual indent
+# E128 continuation line under-indented for visual indent
+# E131 continuation line unaligned for hanging indent
+# E222 multiple spaces after operator
+# E226 missing whitespace around arithmetic operator
+# E231 missing whitespace after
+# E251 unexpected spaces around keyword / parameter equals
+# E261 at least two spaces before inline comment
+# E265 block comment should start with '# '
+# E302 expected 2 blank lines, found 1
+# E402 module level import not at top of file
+# E714 test for object identity should be 'is not'
+# F401 Imported but unused
+# F403 'from module import *' used; unable to detect undefined names
+# F405 foo may be undefined, or defined from star imports
+# F841 local variable 'foo' is assigned to but never used
+# W391 blank line at end of file


### PR DESCRIPTION
- Add tox file for linting of:
  - bash config files
  - flake8
- Mute all flake8 violations currently not passing
- Run tox as part of Travis build
  (inside one run because build matrix is hard)

This would catch trivial errors like #387.
