### PR TITLE
Add test coverage support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+branch = True
+plugins =
+    django_coverage_plugin
+
+omit = *migrations*

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,9 @@ before_script:
 
 script:
  - tox
- - docker-compose run web python manage.py test cabot
+ - docker-compose run web bash bin/test_with_coverage
+
+after_success:
+  - pip install codecov
+  - pip install django_coverage_plugin==1.3.1
+  - codecov

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN ln -s `which nodejs` /usr/bin/node
 RUN pip install --upgrade pip
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements-dev.txt ./
+RUN pip install --no-cache-dir -r requirements-dev.txt
 
 COPY requirements-plugins.txt ./
 RUN pip install --no-cache-dir -r requirements-plugins.txt

--- a/bin/test_with_coverage
+++ b/bin/test_with_coverage
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -x
+
+output_dir='test-results'
+mkdir -p $output_dir
+
+coverage run --source="./cabot/" manage.py test
+status=$?
+
+coverage report --omit="cabot/cabotapp/tests*"
+coverage xml --omit="cabot/cabotapp/tests*" -o $output_dir/coverage.xml
+coverage html --omit="cabot/cabotapp/tests*" -d $output_dir/htmlcov/
+
+exit $status

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+coverage==4.2
+django_coverage_plugin==1.3.1
+mock==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ gunicorn==18.0
 gevent==1.0.1
 httplib2==0.7.7
 icalendar==3.2
-mock==1.0.1
 psycogreen==1.0
 psycopg2==2.5.1
 pytz==2014.10


### PR DESCRIPTION
- Split out requirements in two files
  (testing and main)

- Add Bash script running test with coverage

- Add .coveragerc configuration file,
  including Django coverage plugin

- Add post-build to Travis script