### PR TITLE
Add libffi-dev and libssl-dev to provision packages

### DIFF
--- a/bin/provision
+++ b/bin/provision
@@ -17,6 +17,8 @@ PACKAGES=(
   'redis-server'
   'libsasl2-dev'
   'libldap2-dev'
+  'libffi-dev'
+  'libssl-dev'
 )
 
 # OS-specific install instructions


### PR DESCRIPTION
In order to overcome version incompatibilities preventing 'vagrant up' from completing successfully