### PR TITLE
Start versioning with 0.6.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,4 @@
+Version 0.6.0
+-------------
+
+* Versioning Introduced.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugins = env['CABOT_PLUGINS_ENABLED'].split(',') if 'CABOT_PLUGINS_ENABLED' in 
 
 setup(
     name='cabot',
-    version='0.0.1-dev',
+    version='0.6.0',
     description="Self-hosted, easily-deployable monitoring and alerts service"
                 " - like a lightweight PagerDuty",
     long_description=open('README.md').read(),


### PR DESCRIPTION
Versioning is long over due. We decided to start versioning at 0.6 to match the django version.

There isn't much reason for this beyond that the next 2 changes will be django upgrades which will bump the version to 0.7 and 0.8
