### PR TITLE
Bump django-compressor after Django upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
 script:
  - tox
  - docker-compose run web bash bin/test_with_coverage
+ - docker-compose run web python manage.py compress --force
 
 after_success:
   - pip install codecov

--- a/cabot/cabotapp/tests/test_urlprefix.py
+++ b/cabot/cabotapp/tests/test_urlprefix.py
@@ -81,6 +81,6 @@ class URLPrefixTestCase(LocalTestCase):
 
             self.assertIn(reverse('services'), response.content)
 
-            resposnse = self.client.get(reverse('system-status'))
+            response_systemstatus = self.client.get(reverse('system-status'))
 
-            self.assertEqual(response.status_code, before_systemstatus.status_code)
+            self.assertEqual(response_systemstatus.status_code, before_systemstatus.status_code)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ celery[redis]==3.1.23
 dj-database-url==0.4.2
 django-appconf==0.6
 django-celery==3.1.17
-django-compressor==1.4
+django-compressor==1.5
 django-filter==0.13
 django-jsonify==0.3.0
 django-mptt==0.6.0


### PR DESCRIPTION
Django-compressor needs to be upgraded after the move to 1.8.