### PR TITLE
Fix all workers running beats

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web:       gunicorn cabot.wsgi:application --config gunicorn.conf
-celery:    celery worker -B -A cabot --loglevel=INFO --concurrency=16 -Ofair
+celery:    celery worker -A cabot --loglevel=INFO --concurrency=16 -Ofair
+beat:      celery beat -A cabot --loglevel=INFO

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web:       python manage.py runserver 0.0.0.0:$PORT
-celery:    celery -A cabot worker --loglevel=DEBUG -B -c 8 -Ofair
+celery:    celery -A cabot worker --loglevel=DEBUG -c 8 -Ofair
+beat:      celery -A cabot beat --loglevel=DEBUG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,18 @@ services:
     env_file:
      - conf/development.env
     image: cabot:web
-    command: python manage.py celery worker -B -A cabot --loglevel=DEBUG --concurrency=16 -Ofair
+    command: python manage.py celery worker -A cabot --loglevel=DEBUG --concurrency=16 -Ofair
+    volumes:
+     - .:/code
+    links:
+     - redis
+     - db
+
+  beat:
+    env_file:
+     - conf/development.env
+    image: cabot:web
+    command: python manage.py celery beat -A cabot --loglevel=DEBUG
     volumes:
      - .:/code
     links:


### PR DESCRIPTION
This caused inaccurate timings and some duplicate jobs running. There
should only ever be a single beat service, whereas we were using a dev
feature to run a beat service on all 16 workers