### PR TITLE
Fix docker container race conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_script:
  - cp conf/development.env.example conf/development.env
  - docker-compose build
  - docker-compose up -d
- - sleep 20
 
 script:
  - tox

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+master
+-------------
+
+* Wait for docker containers to start in docker-entrypoint.sh
+
 Version 0.8.1
 -------------
 


### PR DESCRIPTION
The web container could start running before the database/celery broker was launched. Add wait checks in docker-entrypoint