### PR TITLE
Update CABOT_PLUGINS_ENABLED versions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ master
 -------------
 
 * Wait for docker containers to start in docker-entrypoint.sh
+* Update CABOT_PLUGINS_ENABLED to compatible plugin versions
 
 Version 0.8.1
 -------------

--- a/conf/development.env.example
+++ b/conf/development.env.example
@@ -1,5 +1,5 @@
 # Plugins to be loaded at launch
-CABOT_PLUGINS_ENABLED=cabot_alert_hipchat==1.7.0,cabot_alert_twilio==1.1.4,cabot_alert_email==1.3.1
+CABOT_PLUGINS_ENABLED=cabot_alert_hipchat==1.8.3,cabot_alert_twilio==1.2.0,cabot_alert_email==1.4.3
 
 DEBUG=t
 DATABASE_URL=postgres://postgres@db:5432/postgres

--- a/conf/production.env.example
+++ b/conf/production.env.example
@@ -1,5 +1,5 @@
 # Plugins to be loaded at launch
-CABOT_PLUGINS_ENABLED=cabot_alert_hipchat==1.7.0,cabot_alert_twilio==1.1.4,cabot_alert_email==1.3.1
+CABOT_PLUGINS_ENABLED=cabot_alert_hipchat==1.8.3,cabot_alert_twilio==1.2.0,cabot_alert_email==1.4.3
 
 DATABASE_URL=postgres://cabot:cabot@localhost:5432/index
 DJANGO_SETTINGS_MODULE=cabot.settings


### PR DESCRIPTION
They need to be updated for django 1.7+ compatibility

They are already updated in requirements-plugins.txt but the plugin configs are still used in setup.py