### PR TITLE
Fix database cleanup task

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 master
 ------
 
+* Fix db_clean task failing on large results tables
 * Wait for docker containers to start in docker-entrypoint.sh
 * Update CABOT_PLUGINS_ENABLED to compatible plugin versions
 * Automatically initialise database, assets and superuser on docker container start

--- a/cabot/cabotapp/tasks.py
+++ b/cabot/cabotapp/tasks.py
@@ -95,17 +95,24 @@ def clean_db(days_to_retain=60, batch_size=10000):
     result_ids = to_discard_results[:batch_size].values_list('id', flat=True)
     snapshot_ids = to_discard_snapshots[:batch_size].values_list('id', flat=True)
 
-    if not result_ids:
+    result_count = result_ids.count()
+    snapshot_count = snapshot_ids.count()
+
+    # id__in throws exception if passed an empty list, so guard against it
+    if result_count > 0:
+        StatusCheckResult.objects.filter(id__in=result_ids).delete()
+        logger.info('Processing %s StatusCheckResult objects' % result_count)
+    else:
         logger.info('Completed deleting StatusCheckResult objects')
-    if not snapshot_ids:
+
+    if snapshot_count > 0:
+        ServiceStatusSnapshot.objects.filter(id__in=snapshot_ids).delete()
+        logger.info('Processing %s ServiceStatusSnapshot objects' % snapshot_count)
+    else:
         logger.info('Completed deleting ServiceStatusSnapshot objects')
-    if (not snapshot_ids) and (not result_ids):
-        return
 
-    logger.info('Processing %s StatusCheckResult objects' % len(result_ids))
-    logger.info('Processing %s ServiceStatusSnapshot objects' % len(snapshot_ids))
-
-    StatusCheckResult.objects.filter(id__in=result_ids).delete()
-    ServiceStatusSnapshot.objects.filter(id__in=snapshot_ids).delete()
-
-    clean_db.apply_async(kwargs={'days_to_retain': days_to_retain}, countdown=3)
+    if result_count < batch_size and snapshot_count < batch_size:
+        logger.info('Completed deleted all old records')
+    else:
+        # Re-queue to cleanup remaining records
+        clean_db.apply_async(kwargs={'days_to_retain': days_to_retain, 'batch_size': batch_size}, countdown=3)

--- a/cabot/cabotapp/tasks.py
+++ b/cabot/cabotapp/tasks.py
@@ -89,11 +89,11 @@ def clean_db(days_to_retain=60):
     from .models import StatusCheckResult, ServiceStatusSnapshot
     from datetime import timedelta
 
-    to_discard_results = StatusCheckResult.objects.filter(time__lte=timezone.now()-timedelta(days=days_to_retain))
-    to_discard_snapshots = ServiceStatusSnapshot.objects.filter(time__lte=timezone.now()-timedelta(days=days_to_retain))
+    to_discard_results = StatusCheckResult.objects.filter(time_complete__lte=timezone.now() - timedelta(days=days_to_retain))
+    to_discard_snapshots = ServiceStatusSnapshot.objects.filter(time_complete__lte=timezone.now() - timedelta(days=days_to_retain))
 
-    result_ids = to_discard_results.values_list('id', flat=True)[:100]
-    snapshot_ids = to_discard_snapshots.values_list('id', flat=True)[:100]
+    result_ids = to_discard_results[:10000].values_list('id', flat=True)
+    snapshot_ids = to_discard_snapshots[:10000].values_list('id', flat=True)
 
     if not result_ids:
         logger.info('Completed deleting StatusCheckResult objects')
@@ -109,4 +109,3 @@ def clean_db(days_to_retain=60):
     ServiceStatusSnapshot.objects.filter(id__in=snapshot_ids).delete()
 
     clean_db.apply_async(kwargs={'days_to_retain': days_to_retain}, countdown=3)
-


### PR DESCRIPTION
The task was failing for 2 reasons:

1. It was selecting ALL results, flattening them into a list and only
then truncating to 100. The table has 46 million rows. Fix this by
truncating in the database before flattening to a list.

2. The sql query was very expensive, this is because it was filtering
by *time*, but sorting on *time_complete* (the default ordering)


edit: I did some maths and to clear our backlog of ~46m results, it would take over 3 years at 100 results every 3 seconds. I bumped it up to 10k instead