### PR TITLE
Pass arguments through to bin/test_with_coverage

### DIFF
--- a/bin/test_with_coverage
+++ b/bin/test_with_coverage
@@ -4,7 +4,7 @@ set -x
 output_dir='test-results'
 mkdir -p $output_dir
 
-coverage run --source="./cabot/" manage.py test
+coverage run --source="./cabot/" manage.py test $@
 status=$?
 
 coverage report --omit="cabot/cabotapp/tests*"


### PR DESCRIPTION
This lets us call it with e.g. -v2