### PR TITLE
Test migrating from previous tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ before_script:
 script:
  - tox
  - docker-compose -f docker-compose-test.yml run --rm test bash bin/test_with_coverage -v2
+ - git checkout $(git describe --abbrev=0 --tags `git describe --abbrev=0 --tags`^)
+ - docker-compose run --rm -e CABOT_SUPERUSER_USERNAME='admin' -e CABOT_SUPERUSER_PASSWORD='pass' web true
+ - git checkout -
  - docker-compose run --rm -e CABOT_SUPERUSER_USERNAME='admin' -e CABOT_SUPERUSER_PASSWORD='pass' web true
 
 after_success:


### PR DESCRIPTION
In travis checkout the previous tag and run the docker entrypoint (which migrated and compresses) first.

This means migrations will be tested between the previous tag and the current version, catching any nasty migration errors