### PR TITLE
Add `cabot` entrypoint

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+master
+------
+
+* Add `cabot` executable instead of using python manage.py (for e.g. migrating)
+
 Version 0.9.0
 -------------
 

--- a/cabot/entrypoint.py
+++ b/cabot/entrypoint.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+
+def main():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cabot.settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,10 @@ setup(
     install_requires=requirements + requirements_plugins,
     packages=find_packages(),
     include_package_data=True,
+    entry_points={
+        'console_scripts': [
+            'cabot = cabot.entrypoint:main',
+        ],
+    },
     zip_safe=False
 )


### PR DESCRIPTION
This is to make migrations/etc easier when installing through pip