### PR TITLE
Add cabot_alert_slack as default plugin

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 master
 ------
 
+* Add cabot_alert_slack as default plugin
 * Upgrade to Django 1.10
 * Upgrade to Celery 4
 

--- a/conf/default.env
+++ b/conf/default.env
@@ -1,5 +1,5 @@
 # Plugins to be loaded at launch
-CABOT_PLUGINS_ENABLED=cabot_alert_hipchat==1.8.3,cabot_alert_twilio==1.3.0,cabot_alert_email==1.4.3
+CABOT_PLUGINS_ENABLED=cabot_alert_hipchat,cabot_alert_twilio,cabot_alert_email,cabot_alert_slack
 
 DEBUG=t
 DATABASE_URL=postgres://postgres@db:5432/postgres

--- a/conf/development.env.example
+++ b/conf/development.env.example
@@ -1,5 +1,5 @@
 # Plugins to be loaded at launch
-CABOT_PLUGINS_ENABLED=cabot_alert_hipchat==1.8.3,cabot_alert_twilio==1.3.0,cabot_alert_email==1.4.3
+CABOT_PLUGINS_ENABLED=cabot_alert_hipchat,cabot_alert_twilio,cabot_alert_email,cabot_alert_slack
 
 DEBUG=t
 DATABASE_URL=postgres://postgres@db:5432/postgres

--- a/conf/development.env.example
+++ b/conf/development.env.example
@@ -1,5 +1,5 @@
 # Plugins to be loaded at launch
-CABOT_PLUGINS_ENABLED=cabot_alert_hipchat,cabot_alert_twilio,cabot_alert_email,cabot_alert_slack
+# CABOT_PLUGINS_ENABLED=cabot_alert_hipchat,cabot_alert_twilio,cabot_alert_email,cabot_alert_slack
 
 DEBUG=t
 DATABASE_URL=postgres://postgres@db:5432/postgres

--- a/conf/production.env.example
+++ b/conf/production.env.example
@@ -1,5 +1,5 @@
 # Plugins to be loaded at launch
-CABOT_PLUGINS_ENABLED=cabot_alert_hipchat==1.8.3,cabot_alert_twilio==1.3.0,cabot_alert_email==1.4.3
+CABOT_PLUGINS_ENABLED=cabot_alert_hipchat,cabot_alert_twilio,cabot_alert_email,cabot_alert_slack
 
 DATABASE_URL=postgres://cabot:cabot@localhost:5432/index
 DJANGO_SETTINGS_MODULE=cabot.settings

--- a/conf/production.env.example
+++ b/conf/production.env.example
@@ -1,5 +1,5 @@
 # Plugins to be loaded at launch
-CABOT_PLUGINS_ENABLED=cabot_alert_hipchat,cabot_alert_twilio,cabot_alert_email,cabot_alert_slack
+# CABOT_PLUGINS_ENABLED=cabot_alert_hipchat,cabot_alert_twilio,cabot_alert_email,cabot_alert_slack
 
 DATABASE_URL=postgres://cabot:cabot@localhost:5432/index
 DJANGO_SETTINGS_MODULE=cabot.settings

--- a/requirements-plugins.txt
+++ b/requirements-plugins.txt
@@ -1,3 +1,4 @@
 cabot_alert_email==1.4.3
 cabot_alert_hipchat==1.8.3
 cabot_alert_twilio==1.3.0
+cabot_alert_slack==0.7.0


### PR DESCRIPTION
I removed the plugin app versions from the default envs as they seem unnecessary as they are already in requirements-plugins and packaged by default to the correct versions