### PR TITLE
Automatically reload plugins on server start

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 master
 ------
 
+* Automatically reload plugins after migrating
 * Add cabot_alert_slack as default plugin
 * Upgrade to Django 1.10
 * Upgrade to Celery 4

--- a/cabot/cabotapp/__init__.py
+++ b/cabot/cabotapp/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'cabot.cabotapp.apps.CabotappConfig'

--- a/cabot/cabotapp/apps.py
+++ b/cabot/cabotapp/apps.py
@@ -1,0 +1,14 @@
+from django.apps import AppConfig
+from django.db.models.signals import post_migrate
+
+
+def post_migrate_callback(**kwargs):
+    from cabot.cabotapp.alert import update_alert_plugins
+    update_alert_plugins()
+
+
+class CabotappConfig(AppConfig):
+    name = 'cabot.cabotapp'
+
+    def ready(self):
+        post_migrate.connect(post_migrate_callback, sender=self)

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -707,7 +707,6 @@ class ServiceCreateView(LoginRequiredMixin, CreateView):
     form_class = ServiceForm
 
     def __init__(self, *args, **kwargs):
-        alert.update_alert_plugins()
         super(ServiceCreateView, self).__init__(*args, **kwargs)
 
     def get_success_url(self):


### PR DESCRIPTION
This means when you add a new plugin to your config it will be
visible immediately instead of when you try to create a service