### PR TITLE
do not exclude git because in setup.py requires it

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -148,7 +148,7 @@ def deploy(deploy_version=None):
         remote_dir=deploy_path,
         local_dir='./',
         ssh_opts='-o StrictHostKeyChecking=no',
-        exclude=['.git', 'backups', 'venv',
+        exclude=['backups', 'venv',
                  'static/CACHE', '.vagrant', '*.pyc', 'dev.db'],
     )
     with cd(deploy_path):


### PR DESCRIPTION
```
 1#!/usr/bin/env python
 2import os
 3from setuptools import setup, find_packages
 4from os import environ as env
 5import subprocess
 6
 7from pip.req import parse_requirements
 8
 9requirements = [str(req.req) for req in parse_requirements('requirements.txt', session=False)]
10requirements_plugins = [str(req.req) for req in parse_requirements('requirements-plugins.txt', session=False)]
11
12VERSION = subprocess.check_output(['git', 'describe', '--tags']).strip()
13
14setup(
15    name='cabot',
16    version=VERSION,
17    description="Self-hosted, easily-deployable monitoring and alerts service"
18                " - like a lightweight PagerDuty",
19    long_description=open('README.md').read(),
20    author="Arachnys",
21    author_email='info@arachnys.com',
22    url='http://cabotapp.com',
23    license='MIT',
24    install_requires=requirements + requirements_plugins,
25    packages=find_packages(),
26    include_package_data=True,
27    entry_points={
28        'console_scripts': [
29            'cabot = cabot.entrypoint:main',
30        ],
31    },
32    zip_safe=False
33)
```