### PR TITLE
Fix password input bug.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+master
+------
+
+* Fix basic auth passwords getting reset when editing checks
+
 Version 0.10.3
 --------------
 

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -236,6 +236,12 @@ class HttpStatusCheckForm(StatusCheckForm):
             }),
         })
 
+    def clean_password(self):
+        new_password_value = self.cleaned_data['password']
+        if new_password_value == '':
+            new_password_value = self.initial.get('password')
+        return new_password_value
+
 
 class JenkinsStatusCheckForm(StatusCheckForm):
     class Meta:


### PR DESCRIPTION
By default, Django doesn't render field value for PasswordInput widgets, which means the password field will get overwritten
by an empty string every time a check is edited.

To fix this, we check whether the input is empty and don't modify the password if it is.