### PR TITLE
Persist postgres data between runs using docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,3 +46,8 @@ services:
 
   db:
     image: postgres
+    volumes:
+      - datavolume:/var/lib/postgresql/data
+
+volumes:
+  datavolume:


### PR DESCRIPTION
Problem: Every time you stop or start `docker-compose` you lose the database in Postgres.
Solution: Store the Postgres data in a volume to persist between runs.

Also, thank you for all of the hard work on cabot!