### PR TITLE
Update production.env.example documentation and ordering

### DIFF
--- a/conf/production.env.example
+++ b/conf/production.env.example
@@ -4,6 +4,7 @@
 
 # Used for pointing links back in alerts etc.
 WWW_HTTP_HOST=cabot.example.com
+# Probable values: http, https
 WWW_SCHEME=http
 
 ## Local time zone for this installation. Choices can be found here:
@@ -19,7 +20,9 @@ CABOT_FROM_EMAIL=noreply@example.com
 
 ## Django settings
 CELERY_BROKER_URL=redis://:yourredispassword@localhost:6379/1
-DJANGO_SECRET_KEY=2FL6ORhHwr5eX34pP9mMugnIOd3jzVuT45f7w430Mt5PnEwbcJgma0q8zUXNZ68A
+# Create a random string of mixed case alphanumeric characters, > 40 chars.
+# https://www.browserling.com/tools/random-string is a site that can do this
+DJANGO_SECRET_KEY=CREATE_A_KEY
 
 ## Graphite server settings
 # Hostname of your Graphite server instance (including trailing slash)
@@ -86,6 +89,7 @@ AUTH_LDAP_USER_SEARCH="ou=People,dc=example,dc=com"
 DATABASE_URL=postgres://cabot:cabot@localhost:5432/index
 DJANGO_SETTINGS_MODULE=cabot.settings
 
+DEBUG=False
 LOG_FILE=/dev/null
 
 ## Cabot localhost operating port (point a reverse proxy to here or use Caddy)

--- a/conf/production.env.example
+++ b/conf/production.env.example
@@ -49,7 +49,7 @@ EMAIL_PASSWORD=smtp_password
 # Typical SMTP port 587 configuration
 EMAIL_PORT=587
 EMAIL_USE_TLS=1
-EMAIL_USE_SSL=1
+EMAIL_USE_SSL=0
 
 # Typical SMTP port 25 configuration (with no SSL/TLS)
 # EMAIL_PORT=587

--- a/conf/production.env.example
+++ b/conf/production.env.example
@@ -1,72 +1,94 @@
-# Plugins to be loaded at launch
-# CABOT_PLUGINS_ENABLED=cabot_alert_hipchat,cabot_alert_twilio,cabot_alert_email,cabot_alert_slack
-
-DATABASE_URL=postgres://cabot:cabot@localhost:5432/index
-DJANGO_SETTINGS_MODULE=cabot.settings
-LOG_FILE=/dev/null
-PORT=5000
-VENV=/home/ubuntu/venv
-
-# You shouldn't need to change anything above this line
-
+## Cabot UI URL setup
 # Base path to include before generated URLs.  If not defined, uses `/`
 # URL_PREFIX=/
-
-# Local time zone for this installation. Choices can be found here:
-# http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
-TIME_ZONE=Etc/UTC
-
-# Django admin email
-ADMIN_EMAIL=you@example.com
-CABOT_FROM_EMAIL=noreply@example.com
-
-# URL of calendar to synchronise rota with
-CALENDAR_ICAL_URL=http://www.google.com/calendar/ical/example.ics
-
-# Django settings
-CELERY_BROKER_URL=redis://:yourredispassword@localhost:6379/1
-DJANGO_SECRET_KEY=2FL6ORhHwr5eX34pP9mMugnIOd3jzVuT45f7w430Mt5PnEwbcJgma0q8zUXNZ68A
-
-# Hostname of your Graphite server instance (including trailing slash)
-GRAPHITE_API=http://graphite.example.com/
-GRAPHITE_USER=username
-GRAPHITE_PASS=password
-
-# From parameter for the graphite request. If not defined, by default take -10 minutes
-# GRAPHITE_FROM=-10minute
-
-# User-Agent string used for HTTP checks
-HTTP_USER_AGENT=Cabot
-
-# Hipchat integration
-HIPCHAT_ALERT_ROOM=room_name_or_id
-HIPCHAT_API_KEY=your_hipchat_api_key
-
-# Jenkins integration
-JENKINS_API=https://jenkins.example.com/
-JENKINS_USER=username
-JENKINS_PASS=password
-
-# SMTP settings
-EMAIL_HOST=smtp.gmail.com
-EMAIL_USER=********@gmail.com
-EMAIL_PASSWORD=*********
-EMAIL_PORT=587
-EMAIL_USE_TLS=1
-
-# Twilio integration for SMS and telephone alerts
-TWILIO_ACCOUNT_SID=your_account_sid
-TWILIO_AUTH_TOKEN=your_auth_token
-TWILIO_OUTGOING_NUMBER=+14155551234
 
 # Used for pointing links back in alerts etc.
 WWW_HTTP_HOST=cabot.example.com
 WWW_SCHEME=http
 
-# Use for LDAP authentication
+## Local time zone for this installation. Choices can be found here:
+# http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
+TIME_ZONE=Etc/UTC
+
+## URL of calendar to synchronise rota with
+CALENDAR_ICAL_URL=http://www.google.com/calendar/ical/example.ics
+
+## Django admin email, 'from' address for email alerts
+ADMIN_EMAIL=you@example.com
+CABOT_FROM_EMAIL=noreply@example.com
+
+## Django settings
+CELERY_BROKER_URL=redis://:yourredispassword@localhost:6379/1
+DJANGO_SECRET_KEY=2FL6ORhHwr5eX34pP9mMugnIOd3jzVuT45f7w430Mt5PnEwbcJgma0q8zUXNZ68A
+
+## Graphite server settings
+# Hostname of your Graphite server instance (including trailing slash)
+GRAPHITE_API=http://graphite.example.com/
+GRAPHITE_USER=username
+GRAPHITE_PASS=password
+
+# Graphite stats are evaluated through a time period to identify transient
+# failures. This setting determines how many minutes back a test should
+# evaluate.
+# If not defined, evaluate 'now through 10 minutes ago' (-10minute)
+# GRAPHITE_FROM=-10minute
+
+## User-Agent string used for Cabot HTTP checks
+HTTP_USER_AGENT=Cabot
+
+## Email plugin integration
+EMAIL_HOST=smtp.example.com
+# SMTP authentication settings. To disable SMTP authentication, comment out
+#  both EMAIL_USER and EMAIL_PASSWORD.
+EMAIL_USER=smtp_username
+EMAIL_PASSWORD=smtp_password
+
+# Typical SMTP port 587 configuration
+EMAIL_PORT=587
+EMAIL_USE_TLS=1
+EMAIL_USE_SSL=1
+
+# Typical SMTP port 25 configuration (with no SSL/TLS)
+# EMAIL_PORT=587
+# EMAIL_USE_TLS=0
+# EMAIL_USE_SSL=0
+
+## Hipchat plugin integration
+HIPCHAT_ALERT_ROOM=room_name_or_id
+HIPCHAT_API_KEY=your_hipchat_api_key
+
+## Twilio plugin integration (for SMS and telephone alerts)
+TWILIO_ACCOUNT_SID=your_account_sid
+TWILIO_AUTH_TOKEN=your_auth_token
+TWILIO_OUTGOING_NUMBER=+14155551234
+
+## Jenkins integration
+JENKINS_API=https://jenkins.example.com/
+JENKINS_USER=username
+JENKINS_PASS=password
+
+## Use for LDAP authentication
 AUTH_LDAP=true
 AUTH_LDAP_SERVER_URI=ldap://ldap.example.com
 AUTH_LDAP_BIND_DN="cn=Manager,dc=example,dc=com"
 AUTH_LDAP_BIND_PASSWORD=""
 AUTH_LDAP_USER_FILTER="(uid=%(user)s)"
 AUTH_LDAP_USER_SEARCH="ou=People,dc=example,dc=com"
+
+###########################################################################
+## You shouldn't need to change anything below this line                  #
+###########################################################################
+
+## Plugins to be loaded at launch
+# CABOT_PLUGINS_ENABLED=cabot_alert_email,cabot_alert_hipchat,cabot_alert_twilio,cabot_alert_slack
+
+## Database settings
+DATABASE_URL=postgres://cabot:cabot@localhost:5432/index
+DJANGO_SETTINGS_MODULE=cabot.settings
+
+LOG_FILE=/dev/null
+
+## Cabot localhost operating port (point a reverse proxy to here or use Caddy)
+PORT=5000
+
+VENV=/home/ubuntu/venv


### PR DESCRIPTION
This addresses #500 and partially addresses (at least in the sense of 'documents the behavior') #501. I did not do an exhaustive inventory in the source of all possible options available, but I'd consider this a good first pass at making production.env.example a 'living documentation source'.

Feel free to modify this as desired before merging.