### PR TITLE
Move freezegun to requirements dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 coverage==4.3.4
 django_coverage_plugin==1.5.0
+freezegun==0.3.9
 mock==2.0.0
 ipdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ django-filter==1.0.2
 django-jsonify==0.3.0
 django-polymorphic==1.2
 djangorestframework==3.6.2
-freezegun==0.3.8
 gevent==1.2.1
 greenlet==0.4.12
 gunicorn==19.7.1


### PR DESCRIPTION
`freezegun` is a test dependency and thus belons to `requirements-dev`
Also bumps it from 0.3.8 to latest 0.3.9.