### PR TITLE
Fix JenkinsCheck result status for in-progress builds

### DIFF
--- a/cabot/cabotapp/jenkins.py
+++ b/cabot/cabotapp/jenkins.py
@@ -30,12 +30,12 @@ def get_job_status(jenkins_config, jobname):
     client = _get_jenkins_client(jenkins_config)
     try:
         job = client.get_job(jobname)
-        last_build = job.get_last_build()
+        last_build = job.get_last_completed_build()
 
         ret['status_code'] = 200
         ret['job_number'] = last_build.get_number()
         ret['active'] = job.is_enabled()
-        ret['succeeded'] = (job.is_enabled()) and last_build.is_good()
+        ret['succeeded'] = job.is_enabled() and last_build.is_good()
 
         if job.is_queued():
             in_queued_since = job._data['queueItem']['inQueueSince']  # job.get_queue_item() crashes

--- a/cabot/cabotapp/jenkins.py
+++ b/cabot/cabotapp/jenkins.py
@@ -42,6 +42,7 @@ def get_job_status(jenkins_config, jobname):
             time_blocked_since = datetime.utcfromtimestamp(
                 float(in_queued_since) / 1000).replace(tzinfo=timezone.utc)
             ret['blocked_build_time'] = (timezone.now() - time_blocked_since).total_seconds()
+            ret['queued_job_number'] = job.get_last_buildnumber()
         return ret
     except UnknownJob:
         ret['status_code'] = 404

--- a/cabot/cabotapp/models/jenkins_check_plugin.py
+++ b/cabot/cabotapp/models/jenkins_check_plugin.py
@@ -51,6 +51,7 @@ class JenkinsStatusCheck(StatusCheck):
                         int(status['blocked_build_time']),
                         self.max_queued_build_time,
                     )
+                    result.job_number = status['queued_job_number']
                 else:
                     result.succeeded = status['succeeded']
             else:

--- a/cabot/cabotapp/tests/tests_jenkins.py
+++ b/cabot/cabotapp/tests/tests_jenkins.py
@@ -18,7 +18,7 @@ class TestGetStatus(unittest.TestCase):
 
         self.mock_job = create_autospec(jenkinsapi.job.Job)
         self.mock_job.is_enabled.return_value = True
-        self.mock_job.get_last_build.return_value = self.mock_build
+        self.mock_job.get_last_completed_build.return_value = self.mock_build
 
         self.mock_client = create_autospec(jenkinsapi.jenkins.Jenkins)
         self.mock_client.get_job.return_value = self.mock_job
@@ -63,7 +63,7 @@ class TestGetStatus(unittest.TestCase):
 
     @freeze_time('2017-03-02 10:30')
     @patch("cabot.cabotapp.jenkins._get_jenkins_client")
-    def test_job_queued(self, mock_jenkins):
+    def test_job_queued_last_succeeded(self, mock_jenkins):
         mock_jenkins.return_value = self.mock_client
 
         self.mock_build.is_good.return_value = True
@@ -73,12 +73,38 @@ class TestGetStatus(unittest.TestCase):
                 'inQueueSince': float(timezone.now().strftime('%s')) * 1000
             }
         }
+
         with freeze_time(timezone.now() + timedelta(minutes=10)):
             status = jenkins.get_job_status(self.mock_config, 'foo')
 
         expected = {
             'active': True,
             'succeeded': True,
+            'job_number': 12,
+            'blocked_build_time': 600,
+            'status_code': 200
+        }
+        self.assertEqual(status, expected)
+
+    @freeze_time('2017-03-02 10:30')
+    @patch("cabot.cabotapp.jenkins._get_jenkins_client")
+    def test_job_queued_last_failed(self, mock_jenkins):
+        mock_jenkins.return_value = self.mock_client
+
+        self.mock_build.is_good.return_value = False
+        self.mock_job.is_queued.return_value = True
+        self.mock_job._data = {
+            'queueItem': {
+                'inQueueSince': float(timezone.now().strftime('%s')) * 1000
+            }
+        }
+
+        with freeze_time(timezone.now() + timedelta(minutes=10)):
+            status = jenkins.get_job_status(self.mock_config, 'foo')
+
+        expected = {
+            'active': True,
+            'succeeded': False,
             'job_number': 12,
             'blocked_build_time': 600,
             'status_code': 200

--- a/cabot/cabotapp/tests/tests_jenkins.py
+++ b/cabot/cabotapp/tests/tests_jenkins.py
@@ -68,6 +68,7 @@ class TestGetStatus(unittest.TestCase):
 
         self.mock_build.is_good.return_value = True
         self.mock_job.is_queued.return_value = True
+        self.mock_job.get_last_buildnumber.return_value = 13
         self.mock_job._data = {
             'queueItem': {
                 'inQueueSince': float(timezone.now().strftime('%s')) * 1000
@@ -81,6 +82,7 @@ class TestGetStatus(unittest.TestCase):
             'active': True,
             'succeeded': True,
             'job_number': 12,
+            'queued_job_number': 13,
             'blocked_build_time': 600,
             'status_code': 200
         }
@@ -93,6 +95,7 @@ class TestGetStatus(unittest.TestCase):
 
         self.mock_build.is_good.return_value = False
         self.mock_job.is_queued.return_value = True
+        self.mock_job.get_last_buildnumber.return_value = 13
         self.mock_job._data = {
             'queueItem': {
                 'inQueueSince': float(timezone.now().strftime('%s')) * 1000
@@ -106,6 +109,7 @@ class TestGetStatus(unittest.TestCase):
             'active': True,
             'succeeded': False,
             'job_number': 12,
+            'queued_job_number': 13,
             'blocked_build_time': 600,
             'status_code': 200
         }


### PR DESCRIPTION
If a build is in progress, then every
JenkinsCheck was marked as failed.

Here we set the result of the JenkinsCheck
to be the status of the last completed build.

Closes #551