### PR TITLE
Switch from jenkinsapi to python-jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apk add --no-cache \
         musl-dev \
         libffi-dev \
         openldap-dev \
+        ca-certificates \
         bash
 
 RUN npm install -g \

--- a/cabot/cabotapp/jenkins.py
+++ b/cabot/cabotapp/jenkins.py
@@ -1,10 +1,11 @@
+from __future__ import absolute_import
+
 from datetime import datetime
 
+import jenkins
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.utils import timezone
-from jenkinsapi.custom_exceptions import UnknownJob
-from jenkinsapi.jenkins import Jenkins
 
 logger = get_task_logger(__name__)
 
@@ -14,10 +15,9 @@ JENKINS_CLIENT = None
 def _get_jenkins_client(jenkins_config):
     global JENKINS_CLIENT
     if JENKINS_CLIENT is None:
-        JENKINS_CLIENT = Jenkins(jenkins_config.jenkins_api,
+        JENKINS_CLIENT = jenkins.Jenkins(jenkins_config.jenkins_api,
                                  username=jenkins_config.jenkins_user,
-                                 password=jenkins_config.jenkins_pass,
-                                 lazy=True)
+                                 password=jenkins_config.jenkins_pass)
     return JENKINS_CLIENT
 
 def get_job_status(jenkins_config, jobname):
@@ -29,21 +29,21 @@ def get_job_status(jenkins_config, jobname):
     }
     client = _get_jenkins_client(jenkins_config)
     try:
-        job = client.get_job(jobname)
-        last_build = job.get_last_completed_build()
+        job = client.get_job_info(jobname)
+        last_build = client.get_build_info(jobname, job['lastCompletedBuild']['number'])
 
         ret['status_code'] = 200
-        ret['job_number'] = last_build.get_number()
-        ret['active'] = job.is_enabled()
-        ret['succeeded'] = job.is_enabled() and last_build.is_good()
+        ret['job_number'] = last_build['number']
+        ret['active'] = job['color'] != 'disabled'
+        ret['succeeded'] = ret['active'] and last_build['result'] == 'SUCCESS'
 
-        if job.is_queued():
-            in_queued_since = job._data['queueItem']['inQueueSince']  # job.get_queue_item() crashes
+        if job['inQueue']:
+            in_queued_since = job['queueItem']['inQueueSince']
             time_blocked_since = datetime.utcfromtimestamp(
                 float(in_queued_since) / 1000).replace(tzinfo=timezone.utc)
             ret['blocked_build_time'] = (timezone.now() - time_blocked_since).total_seconds()
-            ret['queued_job_number'] = job.get_last_buildnumber()
+            ret['queued_job_number'] = job['lastBuild']['number']
         return ret
-    except UnknownJob:
+    except jenkins.NotFoundException:
         ret['status_code'] = 404
         return ret

--- a/cabot/cabotapp/tests/tests_basic.py
+++ b/cabot/cabotapp/tests/tests_basic.py
@@ -420,7 +420,7 @@ class TestCheckRun(LocalTestCase):
         self.assertEqual(len(checkresults), 1)
         self.assertFalse(self.jenkins_check.last_result().succeeded)
 
-    @patch('cabot.cabotapp.models.requests.get', throws_timeout)
+    @patch('cabot.cabotapp.models.jenkins_check_plugin.get_job_status', throws_timeout)
     def test_timeout_handling_in_jenkins(self):
         """This works because we are effectively patching requests.get globally, including in jenkinsapi."""
         checkresults = self.jenkins_check.statuscheckresult_set.all()

--- a/cabot/cabotapp/tests/tests_jenkins.py
+++ b/cabot/cabotapp/tests/tests_jenkins.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from freezegun import freeze_time
-from mock import patch, create_autospec
+from datetime import timedelta
+
+import jenkins
 from cabot.cabotapp import jenkins
 from cabot.cabotapp.models import JenkinsConfig
 from django.utils import timezone
-from datetime import timedelta
-import jenkinsapi
-from jenkinsapi.custom_exceptions import UnknownJob
+from freezegun import freeze_time
+from mock import create_autospec, patch
+
 
 class TestGetStatus(unittest.TestCase):
 
@@ -20,7 +21,7 @@ class TestGetStatus(unittest.TestCase):
         self.mock_job.is_enabled.return_value = True
         self.mock_job.get_last_completed_build.return_value = self.mock_build
 
-        self.mock_client = create_autospec(jenkinsapi.jenkins.Jenkins)
+        self.mock_client = create_autospec(jenkins.Jenkins)
         self.mock_client.get_job.return_value = self.mock_job
 
         self.mock_config = create_autospec(JenkinsConfig)

--- a/cabot/cabotapp/tests/tests_jenkins.py
+++ b/cabot/cabotapp/tests/tests_jenkins.py
@@ -26,7 +26,6 @@ class TestGetStatus(unittest.TestCase):
             u'color': 'blue'
         }
 
-
         self.build = {
             u'number': 12,
             u'result': u'SUCCESS'

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ gunicorn==19.7.1
 httplib2==0.10.3
 icalendar==3.11.3
 itypes==1.1.0
-jenkinsapi==0.3.4
+python-jenkins==0.4.15
 Jinja2==2.9.6
 kombu==4.0.2
 Markdown==2.6.8


### PR DESCRIPTION
jenkinsapi has terrible performance (between 4 and 14seconds for a
jenkins check) - switch to the openstack library which is lower level.