### PR TITLE
add content conversion to unicode if needed

### DIFF
--- a/cabot/cabotapp/models/base.py
+++ b/cabot/cabotapp/models/base.py
@@ -778,7 +778,9 @@ class HttpStatusCheck(StatusCheck):
                 result.succeeded = False
                 result.raw_data = resp.content
             elif self.text_match:
-                if not re.search(self.text_match, resp.content):
+                # It will convert content to unicode if needed
+                content = resp.content if isinstance(resp.content, unicode) else unicode(resp.content, "UTF-8")
+                if not re.search(self.text_match, content):
                     result.error = u'Failed to find match regex /%s/ in response body' % self.text_match
                     result.raw_data = resp.content
                     result.succeeded = False

--- a/cabot/cabotapp/models/base.py
+++ b/cabot/cabotapp/models/base.py
@@ -751,6 +751,7 @@ class HttpStatusCheck(StatusCheck):
     def check_category(self):
         return "HTTP check"
 
+    @classmethod
     def _check_content_pattern(self, text_match, content):
         content = content if isinstance(content, unicode) else unicode(content, "UTF-8")
         return re.search(text_match, content)

--- a/cabot/cabotapp/models/base.py
+++ b/cabot/cabotapp/models/base.py
@@ -751,6 +751,10 @@ class HttpStatusCheck(StatusCheck):
     def check_category(self):
         return "HTTP check"
 
+    def _check_content_pattern(self, text_match, content):
+        content = content if isinstance(content, unicode) else unicode(content, "UTF-8")
+        return re.search(text_match, content)
+
     def _run(self):
         result = StatusCheckResult(status_check=self)
 
@@ -778,9 +782,7 @@ class HttpStatusCheck(StatusCheck):
                 result.succeeded = False
                 result.raw_data = resp.content
             elif self.text_match:
-                # It will convert content to unicode if needed
-                content = resp.content if isinstance(resp.content, unicode) else unicode(resp.content, "UTF-8")
-                if not re.search(self.text_match, content):
+                if not self._check_content_pattern(self.text_match, resp.content):
                     result.error = u'Failed to find match regex /%s/ in response body' % self.text_match
                     result.raw_data = resp.content
                     result.succeeded = False

--- a/cabot/cabotapp/tests/tests_basic.py
+++ b/cabot/cabotapp/tests/tests_basic.py
@@ -1265,9 +1265,8 @@ class TestHttpStatusCheck(TestCase):
     ]
 
     def test_check_content_pattern(self):
-        http_status_check = HttpStatusCheck()
         for item in self.PATTERN_DATASET:
-            if http_status_check._check_content_pattern(item["pattern"], item["content"]):
+            if HttpStatusCheck._check_content_pattern(item["pattern"], item["content"]):
                 self.assertTrue(item["result"])
             else:
                 self.assertFalse(item["result"])

--- a/cabot/cabotapp/tests/tests_basic.py
+++ b/cabot/cabotapp/tests/tests_basic.py
@@ -1248,20 +1248,20 @@ class TestMinimizeTargets(LocalTestCase):
 class TestHttpStatusCheck(TestCase):
 
     PATTERN_DATASET = [
-        { "pattern": u"буюЯзйЪ",   "content": "буюЯзйЪ",   "result": True},
-        { "pattern": u"юЯз",       "content": "буюЯзйЪ",   "result": True},
-        { "pattern": u"юЯз1",      "content": "буюЯзйЪ",   "result": False},
-        { "pattern": u"sti",       "content": "testing",   "result": True},
-        { "pattern": u"testing",   "content": "testing",   "result": True},
-        { "pattern": u"test",      "content": "testing",   "result": True},
-        { "pattern": u"test",      "content": u"testing",  "result": True},
-        { "pattern": u"ting",      "content": "testing",   "result": True},
-        { "pattern": u"日出處天子", "content": "日出處天子",  "result": True},
-        { "pattern": u"出處",      "content": "日出處天子",  "result": True},
-        { "pattern": u"出處",      "content": u"日出處天子", "result": True},
-        { "pattern": u"日出天子",   "content": "日出處天子",  "result": False},
-        { "pattern": u"юЯз",       "content": "日出處天子",  "result": False},
-        { "pattern": u"юЯз",       "content": u"日出處天子", "result": False}
+        {"pattern": u"буюЯзйЪ", "content": "буюЯзйЪ", "result": True},
+        {"pattern": u"юЯз", "content": "буюЯзйЪ", "result": True},
+        {"pattern": u"юЯз1", "content": "буюЯзйЪ", "result": False},
+        {"pattern": u"sti", "content": "testing", "result": True},
+        {"pattern": u"testing", "content": "testing", "result": True},
+        {"pattern": u"test", "content": "testing", "result": True},
+        {"pattern": u"test", "content": u"testing", "result": True},
+        {"pattern": u"ting", "content": "testing", "result": True},
+        {"pattern": u"日出處天子", "content": "日出處天子", "result": True},
+        {"pattern": u"出處", "content": "日出處天子", "result": True},
+        {"pattern": u"出處", "content": u"日出處天子", "result": True},
+        {"pattern": u"日出天子", "content": "日出處天子", "result": False},
+        {"pattern": u"юЯз", "content": "日出處天子", "result": False},
+        {"pattern": u"юЯз", "content": u"日出處天子", "result": False}
     ]
 
     def test_check_content_pattern(self):

--- a/cabot/cabotapp/tests/tests_basic.py
+++ b/cabot/cabotapp/tests/tests_basic.py
@@ -24,6 +24,7 @@ from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test.client import Client
 from django.test.utils import override_settings
+from django.test import TestCase
 from django.utils import timezone
 from freezegun import freeze_time
 from mock import Mock, patch
@@ -1242,3 +1243,32 @@ class TestMinimizeTargets(LocalTestCase):
         result = minimize_targets(["prefix.prefix.a.suffix.suffix",
                                    "prefix.prefix.b.suffix.suffix",])
         self.assertEqual(result, ["a", "b"])
+
+
+class TestHttpStatusCheck(TestCase):
+
+    PATTERN_DATASET = [
+        { "pattern": u"буюЯзйЪ",   "content": "буюЯзйЪ",   "result": True},
+        { "pattern": u"юЯз",       "content": "буюЯзйЪ",   "result": True},
+        { "pattern": u"юЯз1",      "content": "буюЯзйЪ",   "result": False},
+        { "pattern": u"sti",       "content": "testing",   "result": True},
+        { "pattern": u"testing",   "content": "testing",   "result": True},
+        { "pattern": u"test",      "content": "testing",   "result": True},
+        { "pattern": u"test",      "content": u"testing",  "result": True},
+        { "pattern": u"ting",      "content": "testing",   "result": True},
+        { "pattern": u"日出處天子", "content": "日出處天子",  "result": True},
+        { "pattern": u"出處",      "content": "日出處天子",  "result": True},
+        { "pattern": u"出處",      "content": u"日出處天子", "result": True},
+        { "pattern": u"日出天子",   "content": "日出處天子",  "result": False},
+        { "pattern": u"юЯз",       "content": "日出處天子",  "result": False},
+        { "pattern": u"юЯз",       "content": u"日出處天子", "result": False}
+    ]
+
+    def test_check_content_pattern(self):
+        http_status_check = HttpStatusCheck()
+        for item in self.PATTERN_DATASET:
+            if http_status_check._check_content_pattern(item["pattern"], item["content"]):
+                self.assertTrue(item["result"])
+            else:
+                self.assertFalse(item["result"])
+


### PR DESCRIPTION
1) The issue:
I use Cyrillic website. The match check doesn't work for it. 
I debug the issue and I found the problem source. Django by default represent model fields as UTF-8 unicode . The library "content" is represented as string. (python 2 default docker container). 

2) Solution: 
It will convert content string to UTF-8 unicode if needed.