### PR TITLE
Add isort configuration to sort imports

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ django_coverage_plugin==1.5.0
 freezegun==0.3.9
 mock==2.0.0
 ipdb
+isort==4.2.15

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[isort]
+known_first_party = cabot
+known_third_party = celery,jenkins,freezegun,twilio,requests
+multi_line_output = 5
+known_django = django,polymorphic,rest_framework
+sections = FUTURE,STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,LOCALFOLDER
+skip_glob =	**/migrations/*

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,21 @@ deps =
 	flake8-debugger
 commands = flake8 {posargs}
 
+[testenv:isort]
+deps = isort==4.2.15
+commands =
+    bash -c "find {toxinidir} \
+        -type d \
+            \( \
+              -path {toxinidir}/.git -o \
+              -path {toxinidir}/.tox -o \
+              -path {toxinidir}/.venv -o \
+              -path {toxinidir}/plugins -o \
+              -path {toxinidir}/node_modules \
+            \) -prune -o \
+        -name '*.py' \
+        -print | xargs isort {posargs:--check-only} --verbose"
+
 [flake8]
 exclude = .venv,venv,.tox,dist,doc,build,*.egg,docs,setup.py,*/migrations/
 ignore = E121,E123,E125,E126,E127,E128,E131,E222,E226,E231,E251,E261,E265,E302,E305,E402,E714,F401,F403,F405,F841,W391


### PR DESCRIPTION
isort is a Python utility to  to sort imports alphabetically,
and automatically separated into sections.

This config matches the Django coding style:
https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#imports
```
Put imports in these groups: future, standard library, third-party libraries,
other Django components, local Django component, try/excepts.
```