### PR TITLE
Add Bash linting using bashate

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 set -e
 
-function wait_for_broker {(
+function wait_for_broker {
   set +e
   for try in {1..60} ;  do
     python -c "from kombu import Connection; x=Connection('$CELERY_BROKER_URL', timeout=1); x.connect()" && break
     echo "Waiting for celery broker to respond..."
     sleep 1
   done
-)}
+}
 
-function wait_for_database {(
+function wait_for_database {
   set +e
   for try in {1..60} ; do
     python -c "from django.db import connection; connection.connect()" && break
     echo "Waiting for database to respond..."
     sleep 1
   done
-)}
+}
 
-function wait_for_migrations {(
+function wait_for_migrations {
   set +e
   for try in {1..60} ; do
     # Kind of ugly but not sure if there's another way to determine if migrations haven't run.
@@ -28,7 +28,7 @@ function wait_for_migrations {(
     echo "Waiting for database migrations to be run..."
     sleep 1
   done
-)}
+}
 
 
 wait_for_broker

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,28 @@
 [tox]
-envlist = config,flake8
+envlist = config,flake8,bashate
 skipsdist = True
+
+[testenv]
+whitelist_externals =
+    bash
 
 [testenv:config]
 commands =
     /bin/bash -c 'set -euo pipefail && . ./conf/production.env.example'
     /bin/bash -c 'set -euo pipefail && . ./conf/development.env.example'
+
+[testenv:bashate]
+deps = bashate==0.5.1
+commands =
+    # Run bashate check for all bash scripts
+    # Ignores the following rules:
+    #     E003: Indent not multiple of 4 (we use multiples of 2)
+    #     E006: Line longer than 79 columns
+    bash -c "grep --recursive --binary-files=without-match \
+        --files-with-match '^.!.*\(ba\)\?sh$' \
+        --exclude-dir .tox \
+        --exclude-dir .git \
+        {toxinidir} | xargs bashate --error . --verbose --ignore=E003,E006"
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
bashate is "a pep8 equivalent for bash scripts" by OpenStack.
https://docs.openstack.org/bashate/latest/

- Add tox target running bashate on the entire code-base
- Fix docker-entrypoint script accordingly