### PR TITLE
Better error message when job has no build

### DIFF
--- a/cabot/cabotapp/jenkins.py
+++ b/cabot/cabotapp/jenkins.py
@@ -25,7 +25,10 @@ def get_job_status(jenkins_config, jobname):
     client = _get_jenkins_client(jenkins_config)
     try:
         job = client.get_job_info(jobname)
-        last_build = client.get_build_info(jobname, job['lastCompletedBuild']['number'])
+        last_completed_build = job['lastCompletedBuild']
+        if not last_completed_build:
+            raise Exception("job has no build")
+        last_build = client.get_build_info(jobname, last_completed_build['number'])
 
         ret['status_code'] = 200
         ret['job_number'] = last_build['number']


### PR DESCRIPTION
If a job has no build yet, then the check result was
`'NoneType' object has no attribute '__getitem__'`,
making it hard to understand what is going on.

Now we catch that issue early-on and raise an Exception.

All in all this is not great code - we should decide once and for all
if get_job_status is supposed to bubble up issues as return_codes
or if we can use Exceptions.