### PR TITLE
Use sudo to install pip package in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ script:
  - docker-compose run --rm web true
 
 after_success:
-  - pip install codecov
-  - pip install django_coverage_plugin==1.4.2
+  - sudo pip install codecov
+  - sudo pip install django_coverage_plugin==1.4.2
   - codecov


### PR DESCRIPTION
This has started failing with variations on:
```
OSError: [Errno 13] Permission denied: '/usr/local/lib/python2.7/dist-packages/pytz-2017.2.dist-info'
```

Executing under sudo is hardly a solution, but a suggested workaround
per https://github.com/travis-ci/travis-ci/issues/1705
(and we are doing it already to install tox)