### PR TITLE
if head of the [0- debounce] checks is all faild, debounce args lose efficacy

### DIFF
--- a/cabot/cabotapp/models/base.py
+++ b/cabot/cabotapp/models/base.py
@@ -59,6 +59,9 @@ def calculate_debounced_passing(recent_results, debounce=0):
     """
     if not recent_results:
         return True
+    # fix when the first run, if the first 0 - debounce checks all error and mark result faild
+    if len(recent_results) < debounce:
+        return True
     debounce_window = recent_results[:debounce + 1]
     for r in debounce_window:
         if r.succeeded:


### PR DESCRIPTION
when i set up a new check, and set debounce = 5 , if the first check is faild , there will be alarms。

looks like:
```python
"""
case when:
len(recent_results) = 1 and recent_results.succeeded = 0

exec result:
return False
"""

def calculate_debounced_passing(recent_results, debounce=0):
    """
    `debounce` is the number of previous failures we need (not including this)
    to mark a search as passing or failing
    Returns:
      True if passing given debounce factor
      False if failing
    """
    if not recent_results:
        return True
    debounce_window = recent_results[:debounce + 1]
    for r in debounce_window:
        if r.succeeded:
            return True
    return False

```