### PR TITLE
Cabot sends `None` string in HTTP status checks in auth header for username or password

### DIFF
--- a/cabot/cabotapp/models/base.py
+++ b/cabot/cabotapp/models/base.py
@@ -760,7 +760,8 @@ class HttpStatusCheck(StatusCheck):
 
         auth = None
         if self.username or self.password:
-            auth = (self.username, self.password)
+            auth = (self.username if self.username is not None else '',
+                    self.password if self.password is not None else '')
 
         try:
             resp = requests.get(


### PR DESCRIPTION
Due to non-obvious behaviour in `requests` (https://github.com/requests/requests/issues/4465), the way in which Cabot currently constructs its auth for HTTP status checks results in the string of `None` being sent as part of Authorization header.

In short, because the Python object `None` gets passed into the auth tuple in https://github.com/arachnys/cabot/blob/master/cabot/cabotapp/models/base.py#L760, requests takes this and converts it to a string, resulting in an Authorization header that decodes to `my_api_key_orusername:None`, which then breaks authentication for URLs/APIs (like GitHub) that only require a username.

In this case, the solution is to ensure `requests.get` is passed an a empty string for the password if one isn't specified.  To get to this point, I can see two options: either this PR, which is a basic check for the object of `None`, or otherwise modify the Django models & database to use an empty string (ala https://docs.djangoproject.com/en/2.0/ref/models/fields/#null).

The former is simplest as it doesn't change the data model and/or require migration; but the latter is probably the cleaner of the two options.