### PR TITLE
Bump Django to 1.11.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ celery==4.0.2
 coreapi==2.3.0
 coreschema==0.0.4
 dj-database-url==0.4.2
-Django==1.11.6
+Django==1.11.11
 django-appconf==1.0.2
 django-auth-ldap==1.2.16
 django-autocomplete-light==3.2.10


### PR DESCRIPTION
There are vulnerabilities for the intermediate versions.

Changelog: https://docs.djangoproject.com/en/2.0/releases/#id1