### PR TITLE
Fix lack of spacing in far right user dropdown menu

### DIFF
--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -1010,6 +1010,7 @@ class SetupView(View):
 
 class OnCallView(APIView):
     queryset = User.objects
+
     def get(self, request):
         users = get_duty_officers()
 

--- a/cabot/templates/base.html
+++ b/cabot/templates/base.html
@@ -57,10 +57,10 @@
                 <a href="{% url "admin:auth_user_add" %}"><i class="glyphicon glyphicon-user"></i> Add user</a>
               </li>
               <li>
-                <a href="{% url "user-profile" user.id %}"><i class="glyphicon glyphicon-wrench"></i>Profile Settings</a>
+                <a href="{% url "user-profile" user.id %}"><i class="glyphicon glyphicon-wrench"></i> Profile Settings</a>
               </li>
               <li>
-                <a href="{% url "plugin-settings-global" %}"><i class="glyphicon glyphicon-equalizer"></i>Plugin Settings</a>
+                <a href="{% url "plugin-settings-global" %}"><i class="glyphicon glyphicon-equalizer"></i> Plugin Settings</a>
               </li>
               <li class="divider"></li>
               <li>


### PR DESCRIPTION
To illustrate the bug:

![screenshot_20180416_010338_cabot_menu](https://user-images.githubusercontent.com/1577132/38784486-b2dd15f4-4112-11e8-99ac-483d651516dd.png)

Please consider this fix.