### PR TITLE
Prevent auto-fill of saved credentials into HTTP auth fields

### DIFF
--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -228,6 +228,8 @@ class HttpStatusCheckForm(StatusCheckForm):
             }),
             'password': forms.PasswordInput(attrs={
                 'style': 'width: 30%',
+                # Prevent auto-fill with saved Cabot log-in credentials:
+                'autocomplete': 'new-password',
             }),
             'text_match': forms.TextInput(attrs={
                 'style': 'width: 100%',


### PR DESCRIPTION
Proposed approach to handle #605.

Tried with Firefox 58, Chromium 63, Chrome 66.