### PR TITLE
Fix HTTP check for websites serving non-UTF-8 content

### DIFF
--- a/cabot/cabotapp/models/base.py
+++ b/cabot/cabotapp/models/base.py
@@ -782,7 +782,7 @@ class HttpStatusCheck(StatusCheck):
                 result.succeeded = False
                 result.raw_data = resp.content
             elif self.text_match:
-                if not self._check_content_pattern(self.text_match, resp.content):
+                if not self._check_content_pattern(self.text_match, resp.text):
                     result.error = u'Failed to find match regex /%s/ in response body' % self.text_match
                     result.raw_data = resp.content
                     result.succeeded = False

--- a/cabot/cabotapp/models/base.py
+++ b/cabot/cabotapp/models/base.py
@@ -780,11 +780,11 @@ class HttpStatusCheck(StatusCheck):
                 result.error = u'Wrong code: got %s (expected %s)' % (
                     resp.status_code, int(self.status_code))
                 result.succeeded = False
-                result.raw_data = resp.content
+                result.raw_data = resp.text
             elif self.text_match:
                 if not self._check_content_pattern(self.text_match, resp.text):
                     result.error = u'Failed to find match regex /%s/ in response body' % self.text_match
-                    result.raw_data = resp.content
+                    result.raw_data = resp.text
                     result.succeeded = False
                 else:
                     result.succeeded = True

--- a/cabot/cabotapp/tests/tests_basic.py
+++ b/cabot/cabotapp/tests/tests_basic.py
@@ -461,6 +461,8 @@ class TestCheckRun(LocalTestCase):
         self.assertFalse(self.http_check.last_result().succeeded)
         self.assertEqual(self.http_check.calculated_status,
                          Service.CALCULATED_FAILING_STATUS)
+        self.assertIn(u'Failed to find match regex',
+            self.http_check.last_result().error)
 
     @patch('cabot.cabotapp.models.requests.get', throws_timeout)
     def test_timeout_handling_in_http(self):

--- a/cabot/cabotapp/tests/tests_basic.py
+++ b/cabot/cabotapp/tests/tests_basic.py
@@ -178,6 +178,7 @@ def jenkins_blocked_response(*args, **kwargs):
 def fake_http_200_response(*args, **kwargs):
     resp = Mock()
     resp.content = get_content('http_response.html')
+    resp.text = unicode(resp.content, 'utf-8')
     resp.status_code = 200
     return resp
 
@@ -185,6 +186,7 @@ def fake_http_200_response(*args, **kwargs):
 def fake_http_404_response(*args, **kwargs):
     resp = Mock()
     resp.content = get_content('http_response.html')
+    resp.text = unicode(resp.content, 'utf-8')
     resp.status_code = 404
     return resp
 


### PR DESCRIPTION
Fixes issue #607.

`Response.content` is of type `str` and needs decoding. In contrast, Response.text is of type `unicode`, already. This way, we no longer need to mis-assume UTF-8.

Docs:
http://docs.python-requests.org/en/master/user/quickstart/#response-content