### PR TITLE
Style forms using django-bootstrap-form 3.4

### DIFF
--- a/cabot/settings.py
+++ b/cabot/settings.py
@@ -147,6 +147,7 @@ INSTALLED_APPS = (
     'dal',
     'dal_select2',
     'django.contrib.admin',
+    'bootstrapform',
 )
 
 AUTH_USER_MODEL = 'auth.User'

--- a/cabot/templates/cabotapp/_base_form.html
+++ b/cabot/templates/cabotapp/_base_form.html
@@ -1,3 +1,5 @@
+{% load bootstrap %}
+
 <div class="form-group">
   <div class="col-xs-10 col-xs-offset-2">
     {{ form.non_field_errors }}
@@ -9,10 +11,10 @@
   <div class="col-xs-12">
     <label class="col-xs-2 control-label">{{ field.label_tag }}</label>
     {% if field.errors %}
-    <div class="col-xs-7">{{ field }}</div>
+    <div class="col-xs-7">{{ field|bootstrap_inline }}</div>
     <div class="col-xs-3 alert alert-danger">{{ field.errors }}</div>
     {% else %}
-    <div class="col-xs-10">{{ field }}</div>
+    <div class="col-xs-10">{{ field|bootstrap_inline }}</div>
     {% endif %}
   </div>
   {% if field.name == 'metric' %}
@@ -23,11 +25,6 @@
     </div>
   </div>
   {% else %}
-  {% endif %}
-  {% if field.help_text %}
-  <div class="col-xs-12">
-    <div class="col-xs-7 col-xs-offset-2"><p class="help-block">{{ field.help_text }}</p></div>
-  </div>
   {% endif %}
 </div>
 {% endfor %}

--- a/cabot/templates/cabotapp/alertpluginuserdata_form.html
+++ b/cabot/templates/cabotapp/alertpluginuserdata_form.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% load bootstrap %}
+
 {% block content %}
 <div class="container-fluid">
   <div class="row">
@@ -18,7 +20,7 @@
         {% for field in form %}
         <div class="form-group">
           <label class="col-xs-2 control-label">{{ field.label_tag }}</label>
-          <div class="col-xs-10">{{ field }}</div>
+          <div class="col-xs-10">{{ field|bootstrap_inline }}</div>
         </div>
         {% endfor %}
         <div class="form-group">

--- a/cabot/templates/cabotapp/plugin_settings_form.html
+++ b/cabot/templates/cabotapp/plugin_settings_form.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% load bootstrap %}
+
 {% block content %}
 <div class="container-fluid">
   <div class="row">
@@ -21,7 +23,7 @@
         {% for field in form %}
         <div class="form-group">
           <label class="col-xs-2 control-label">{{ field.label_tag }}</label>
-          <div class="col-xs-6">{{ field }}</div>
+          <div class="col-xs-6">{{ field|bootstrap_inline }}</div>
         </div>
         {% endfor %}
         <div class="form-group">
@@ -36,12 +38,12 @@
       <form class="form-horizontal" action="{{ alert_test_form.action }}" method="post" role="form">
         {% csrf_token %}
         {% for field in alert_test_form.hidden_fields %}
-        {{ field }}
+        {{ field|bootstrap_inline }}
         {% endfor %}
         {% for field in alert_test_form.visible_fields %}
         <div class="form-group">
           <label class="col-xs-2 control-label">{{ field.label_tag }}</label>
-          <div class="col-xs-6">{{ field }}</div>
+          <div class="col-xs-6">{{ field|bootstrap_inline }}</div>
         </div>
         {% endfor %}
         <div class="form-group">

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ Django==1.11.11
 django-appconf==1.0.2
 django-auth-ldap==1.2.16
 django-autocomplete-light==3.2.10
+django-bootstrap-form==3.4
 django-compressor==2.2
 django-filter==1.0.4
 django-jsonify==0.3.0


### PR DESCRIPTION
Candidate for #608.

Potentially one of the least invasive approaches to apply Bootstrap3 styling.
`field.help_text` was removed so that it's not shown twice.

Project home:
- https://github.com/tzangms/django-bootstrap-form
- https://pypi.org/project/django-bootstrap-form/