### PR TITLE
Reduce branding a bit?

### DIFF
--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -222,7 +222,7 @@ class HttpStatusCheckForm(StatusCheckForm):
         widgets.update({
             'endpoint': forms.TextInput(attrs={
                 'style': 'width: 100%',
-                'placeholder': 'https://www.arachnys.com',
+                'placeholder': 'https://www.example.org/',
             }),
             'username': forms.TextInput(attrs={
                 'style': 'width: 30%',

--- a/cabot/templates/base_public.html
+++ b/cabot/templates/base_public.html
@@ -4,7 +4,7 @@
 <head>
 
   <meta charset="utf-8">
-  <title>{% block title %}Cabot by Arachnys{% endblock title %}</title>
+  <title>{% block title %}Cabot{% endblock title %}</title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {% load compress %}
@@ -37,7 +37,7 @@
   <div class="navbar navbar-default navbar-fixed-top">
     <div class="container">
       <div class="navbar-header">
-        <a href="{% url 'dashboard' %}" class="navbar-brand"><img src="{% static 'arachnys/img/icon_48x48.png' %}" width='20' height='20' /> Cabot by Arachnys</a>
+        <a href="{% url 'dashboard' %}" class="navbar-brand"><img src="{% static 'arachnys/img/icon_48x48.png' %}" width='20' height='20' /> Cabot</a>
         <button class="navbar-toggle" type="button" data-toggle="collapse" data-target="#navbar-main">
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>


### PR DESCRIPTION
Hi!

This pull request is probably controversial.  It is meant to start a discussion.

It may be a personal thing, a European thing, a cultural thing, you tell me.  When I use software I don't like to look at company names all the time, the same way I try to keep my life as free from advertisements as possible.  There are places where branding feels organic and fits in but there are two places in Cabot where I personally find the branding to invasive: they get too much attention in a way that is hard to look by.  For daily operation, that matters. So this pull request reduces use of the Arachnys brand _a bit_.

Branding that is *kept untouched* includes:
* Everything in `README.md`
* The Arachnys company logo left of "Cabot" in the top nagivation bar and the effective favicon
* The regex placeholder `[Aa]rachnys\s+[Rr]ules`

Branding that is removed:
* Text `by Arachnys` in the top navigation bar and page title
* Placeholder text `https://www.arachnys.com` for an HTTP check endpoint example URL

I'm happy to introduce a switch `DEBRAND=False` or so to `development.env` and friends to make this change conditional if it's more of the right direction.

What do you think?