### PR TITLE
Fix 404 page for anonymous user

### DIFF
--- a/cabot/cabotapp/tests/tests_basic.py
+++ b/cabot/cabotapp/tests/tests_basic.py
@@ -559,6 +559,19 @@ class TestWebInterface(LocalTestCase):
         super(TestWebInterface, self).setUp()
         self.client = Client()
 
+    def test_404_page_anonymous_user(self):
+        response = self.client.get('/not/found/for/sure')
+        self.assertIn('Page not found.', response.content)
+        self.assertNotIn('Profile Settings', response.content)
+        self.assertEqual(response.status_code, 404)
+
+    def test_404_page_logged_in_user(self):
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.get('/not/found/for/sure')
+        self.assertIn('Page not found.', response.content)
+        self.assertIn('Profile Settings', response.content)
+        self.assertEqual(response.status_code, 404)
+
     def test_set_recovery_instructions(self):
         # Get service page - will get 200 from login page
         resp = self.client.get(reverse('update-service', kwargs={'pk':self.service.id}), follow=True)

--- a/cabot/templates/base.html
+++ b/cabot/templates/base.html
@@ -1,5 +1,6 @@
 {% extends 'base_public.html' %}
 {% block header_navbar_menu %}
+  {% if user.is_authenticated %}
   <ul class="nav navbar-nav">
     <li>
       <a href="{% url 'instances' %}"><i class="fa fa-desktop"></i> Instances</a>
@@ -73,4 +74,7 @@
             </ul>
           </li>
         </ul>
+  {% else %}
+    {{ block.super }}
+  {% endif %}
 {% endblock header_navbar_menu %}


### PR DESCRIPTION
Meant to fix #624.

The anonymous user has ID `None`.  Previously, this exception was raised:
```
NoReverseMatch: Reverse for 'user-profile' with arguments '(None,)' not found. 1 pattern(s) tried: ['user/(?P<pk>\\d+)/profile/$']
```