### PR TITLE
Fix custom check plugins list on checks page

### DIFF
--- a/cabot/templates/cabotapp/_statuscheck_list.html
+++ b/cabot/templates/cabotapp/_statuscheck_list.html
@@ -3,8 +3,8 @@
 <div class="row">
   <div class="col-xs-12">
     <div class="col-xs-1"><h3><i class="{% if checks_type == "All" %}fa fa-cog{% else %}glyphicon glyphicon-{% if checks_type == "Http" %}arrow-up{% elif checks_type == "Jenkins" %}ok{% elif checks_type == "ICMP" %}transfer{% else %}signal{% endif %}{% endif %}"></i></h3></div>
-    <div class="col-xs-8"><h3>{{ checks_type }} checks</h3></div>
-    <div class="col-xs-3 text-right">
+    <div class="col-xs-3"><h3>{{ checks_type }} checks</h3></div>
+    <div class="col text-right">
       <h3>
       &nbsp;{% if checks_type == "All" or checks_type == "Graphite" %}
       <a href="{% url "create-graphite-check" %}?instance={{ instance.id }}&service={{ service.id }}" class=""><i class="glyphicon glyphicon-plus" title="Add new metric check"></i><i class="glyphicon glyphicon-signal" title="Add new metric check"></i></a>


### PR DESCRIPTION
This is a very minor change, but when additional custom checks are added, the list of available checks begin to stack. My change just allows them to adjust to a single line.