### PR TITLE
Fix graphite display bug, function should be defined before calling

### DIFF
--- a/cabot/templates/cabotapp/statuscheck_form.html
+++ b/cabot/templates/cabotapp/statuscheck_form.html
@@ -36,12 +36,12 @@ GRAPHITE_ENDPOINT = '/graphite/'
 
 $(document).ready ->
   updateGraphiteData()
-  $('#id_metric').on('keyup', complete)
-  $('#id_frequency').on('keyup', complete)
-
   complete = () ->
       clearTimeout(timer)
       timer = setTimeout(updateGraphiteData, 1000)
+
+  $('#id_metric').on('keyup', complete)
+  $('#id_frequency').on('keyup', complete)
 
   $('#id_metric').autocomplete
     source: (request, response) ->


### PR DESCRIPTION
At page "new graphite check", nothing show after I typed graphite metric key.
The reason is that the keyup event callback function should be defined before calling.