### PR TITLE
Add support for providing custom Certificate Autority bundle file

### DIFF
--- a/cabot/cabot_config.py
+++ b/cabot/cabot_config.py
@@ -19,6 +19,7 @@ WWW_HTTP_HOST = os.environ.get('WWW_HTTP_HOST')
 WWW_SCHEME = os.environ.get('WWW_SCHEME', "https")
 
 HTTP_USER_AGENT = os.environ.get('HTTP_USER_AGENT', 'Cabot')
+CABOT_HTTP_CHECK_CA_BUNDLE = os.environ.get('CABOT_HTTP_CHECK_CA_BUNDLE')
 
 # How often should alerts be sent for important failures?
 ALERT_INTERVAL = int(os.environ.get('ALERT_INTERVAL', 10))

--- a/cabot/cabotapp/tasks.py
+++ b/cabot/cabotapp/tasks.py
@@ -99,11 +99,7 @@ def clean_db(days_to_retain=7, batch_size=10000):
     InstanceStatusSnapshot.objects.filter(id__in=instance_snapshot_ids).delete()
 
     # If we reached the batch size on either we need to re-queue to continue cleaning up.
-    if (
-            result_count == batch_size or
-            service_snapshot_count == batch_size or
-            instance_snapshot_count == batch_size
-    ):
+    if result_count == batch_size or service_snapshot_count == batch_size or instance_snapshot_count == batch_size:
         clean_db.apply_async(kwargs={
             'days_to_retain': days_to_retain,
             'batch_size': batch_size},

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -264,7 +264,7 @@ class HttpStatusCheckForm(StatusCheckForm):
             }),
             'text_match': forms.TextInput(attrs={
                 'style': 'width: 100%',
-                'placeholder': '[Aa]rachnys\s+[Rr]ules',
+                'placeholder': r'[Aa]rachnys\s+[Rr]ules',
             }),
             'status_code': forms.TextInput(attrs={
                 'style': 'width: 20%',

--- a/cabot/settings.py
+++ b/cabot/settings.py
@@ -164,7 +164,7 @@ INSTALLED_APPS += tuple(CABOT_PLUGINS_ENABLED_PARSED)
 COMPRESS_PRECOMPILERS = (
     ('text/coffeescript', 'coffee --compile --stdio'),
     ('text/eco',
-     'eco -i TEMPLATES {infile} && cat "$(echo "{infile}" | sed -e "s/\.eco$/.js/g")"'),
+     r'eco -i TEMPLATES {infile} && cat "$(echo "{infile}" | sed -e "s/\.eco$/.js/g")"'),
     ('text/less', 'lessc {infile} > {outfile}'),
 )
 

--- a/conf/default.env
+++ b/conf/default.env
@@ -28,6 +28,9 @@ CELERY_BROKER_URL=redis://redis:6379/1
 # User-Agent string used for HTTP checks
 HTTP_USER_AGENT=Cabot
 
+# CA bundle to use when verifying SSL certificate in HTTP checks. By default the bundle is provided by the Certifi python module
+# CABOT_HTTP_CHECK_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
 # Used for pointing links back in alerts etc.
 WWW_HTTP_HOST=localhost
 WWW_SCHEME=http

--- a/conf/development.env.example
+++ b/conf/development.env.example
@@ -38,6 +38,9 @@ GRAPHITE_PASS=password
 # User-Agent string used for HTTP checks
 HTTP_USER_AGENT=Cabot
 
+# CA bundle to use when verifying SSL certificate in HTTP checks. By default the bundle is provided by the Certifi python module
+# CABOT_HTTP_CHECK_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
 # Hipchat integration
 HIPCHAT_ALERT_ROOM=room_name_or_id
 HIPCHAT_API_KEY=your_hipchat_api_key

--- a/conf/production.env.example
+++ b/conf/production.env.example
@@ -39,6 +39,9 @@ GRAPHITE_PASS=password
 ## User-Agent string used for Cabot HTTP checks
 HTTP_USER_AGENT=Cabot
 
+# CA bundle to use when verifying SSL certificate in HTTP checks. By default the bundle is provided by the Certifi python module
+# CABOT_HTTP_CHECK_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
 ## Email plugin integration
 EMAIL_HOST=smtp.example.com
 # SMTP authentication settings. To disable SMTP authentication, comment out

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,10 @@ from setuptools import setup, find_packages
 from os import environ as env
 import subprocess
 
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 requirements = [str(req.req) for req in parse_requirements('requirements.txt', session=False)]
 requirements_plugins = [str(req.req) for req in parse_requirements('requirements-plugins.txt', session=False)]


### PR DESCRIPTION
# Motivation

In it's current state, Cabot HTTP checks with SSL validation relies on the Python requests module to handle the SSL validation part.

When it comes to validate the server certificate chain, the requests module must know the CA certificate used to sign the presented server certificate. When one want to use Cabot to check an HTTPS server presenting a server certificate signed by a self-signed CA certificate, we need a mean to provide Cabot (and its requests module) with a CA bundle file containing our own certificate.

The python requests module does not use the OS CA certificates store ; instead it uses its own bundle provided by the Python [Certifi](https://pypi.org/project/certifi/) module. 

# Changes

This PR introduces a new optional environment variable: `CABOT_HTTP_CHECK_CA_BUNDLE` which can be used to specify the path of a custom CA cert bundle file. 

```sh
CABOT_HTTP_CHECK_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
`````````


