### PR TITLE
Pin flake8 dependencies to last known working versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,10 @@ commands =
 
 [testenv:flake8]
 deps =
-	flake8
-	flake8-debugger
+  flake8==3.5.0
+  pycodestyle==2.3.1
+  pyflakes==1.6.0
+  flake8-debugger==3.1.0
 commands = flake8 {posargs}
 
 [testenv:isort]


### PR DESCRIPTION
The Travis-CI build has been failing for ages because of flake8:
as the flake8 dependencies were not pinned, the codebase is failing
when using more recent versions of flake8 (or of the underlying pycodestyle).

This pins the dependencies in the tox file to
the last known working versions, as found in [1].

(This is a stop-gap measure, ideally the new violations would be fixed).

[1] https://travis-ci.org/github/arachnys/cabot/builds/424842858