### PR TITLE
Fix travis tests and bump minor Django version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --no-cache \
         ca-certificates \
         bash
 
+RUN npm config set unsafe-perm true
 RUN npm install -g \
         --registry http://registry.npmjs.org/ \
         coffee-script \

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ celery==4.2.1
 coreapi==2.3.0
 coreschema==0.0.4
 dj-database-url==0.4.2
-Django==1.11.11
+Django==1.11.29
 django-appconf==1.0.2
 django-auth-ldap==1.2.16
 django-autocomplete-light==3.2.10


### PR DESCRIPTION
See https://github.com/npm/npm/issues/20861 - AWS issue with M5 machine
family which I guess is what Travis uses under the hood.