### PR TITLE
Security Fix for Stored Cross-site Scripting (XSS) - huntr.dev

### DIFF
--- a/cabot/cabotapp/models/base.py
+++ b/cabot/cabotapp/models/base.py
@@ -9,6 +9,7 @@ import requests
 
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.utils.log import get_task_logger
+from django.core.validators import URLValidator
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
@@ -472,6 +473,7 @@ class StatusCheck(PolymorphicModel):
     endpoint = models.TextField(
         null=True,
         help_text='HTTP(S) endpoint to poll.',
+        validators = [URLValidator()],
     )
     username = models.TextField(
         blank=True,

--- a/cabot/templates/cabotapp/statuscheck_detail.html
+++ b/cabot/templates/cabotapp/statuscheck_detail.html
@@ -78,7 +78,7 @@
           </td>
           <td>{{ result.time_complete }}</td>
           <td>{{ result.took }}</td>
-          <td>{% autoescape off %}{{ result.error|default:"" }}{% endautoescape %}</td>
+          <td>{{ result.error|default:"" }}</td>
         </tr>
       {% endfor %}
       </tbody>


### PR DESCRIPTION
https://huntr.dev/users/alromh87 has fixed the Stored Cross-site Scripting (XSS) vulnerability 🔨. alromh87 has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/cabot/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/pip/cabot/1/README.md

### User Comments:

### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-pip-cabot/

### ⚙️ Description *

Executed Persistent stored XSS in cabot check settings, as well as the address field.

### 💻 Technical Description *

Fixed by using builtin django autoescape and URLValidator

Altough Django has inbuilt protection agains XSS it was disabled for the test result.error by using `{% autoescape off %}`, just to be sure I wasn't breaking any needed functionality I inspected history to depict the porpouse of this change

- Ofending line was introduced in https://github.com/arachnys/cabot/commit/558f18c04e3927def5a9306b014488669006b68b#diff-480f9da2f76d81e98bfb4c99316b90c6R52
- For allowing embeding links in the  response
https://github.com/arachnys/cabot/commit/558f18c04e3927def5a9306b014488669006b68b#diff-9ff30487dc763b21d6a7742d19eb2268R442

- Function was removed a [few commits later](https://github.com/arachnys/cabot/commit/fb761f56034246452411cdacb9303a4b866beaf9#diff-9ff30487dc763b21d6a7742d19eb2268L453) making the use of `{% autoescape off %}` unnecesary 

As an extra I added URLValidator in the Http test model

### 🐛 Proof of Concept (PoC) *


1. Setup cabot to reproduce the vulnerability
2. Create an account now login to the account
3. Go to checks Create and navigate to http check.
4. In the Endpoint column append a XSS payload.
`<script>alert('Hi')</script>`
5. Now we can see a failed check now click run button in that checks
6. XSS triggered
7. XSS will trigger in check result for every time executed for both Test name and Endpoint

![Captura de pantalla de 2020-09-13 12-33-03](https://user-images.githubusercontent.com/7505980/93014874-58766680-f5bd-11ea-904b-9fd6f6120e31.png)

![Captura de pantalla de 2020-09-13 12-32-53](https://user-images.githubusercontent.com/7505980/93014878-59a79380-f5bd-11ea-92bb-a06bb4396810.png)


### Proof of Fix (PoF) *

After fix No code is executed for remote user

![Captura de pantalla de 2020-09-13 12-27-30](https://user-images.githubusercontent.com/7505980/93014795-beaeb980-f5bc-11ea-9eff-75293fa1998b.png)

![Captura de pantalla de 2020-09-13 12-28-33](https://user-images.githubusercontent.com/7505980/93014792-b48cbb00-f5bc-11ea-9ae2-08f31f907eec.png)

Fix will also handle previously stored offending endpoints with XSS

### 👍 User Acceptance Testing (UAT)

After fix functionality is unafected